### PR TITLE
supporting a minimal network setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,24 +96,20 @@ cross-compilation of the basic ros-comm packages.
   Then for example, you start this system in the qemu virtual machine with
 
     runqemu <MACHINE> core-image-ros-roscore
-
   
-  On the Linux system, ensure that the own host's name in resolved by adding
-  
-    127.0.0.1	<HOSTNAME>.localdomain		<HOSTNAME>
-
-  to the /etc/hosts file, and set up the environment with
+  On the qemu virtual machine, you can now login as root and setup the bash
+  environment with:
 
     export ROS_ROOT=/usr
     export ROS_MASTER_URI=http://localhost:11311
     export CMAKE_PREFIX_PATH=/usr
     touch /usr/.catkin
 
-  Finally, you can start roscore with
+  Finally, you start roscore with:
 
     roscore
 
-    
+
 ## LICENSE ##
 
   All metadata is MIT licensed unless otherwise stated. Source code included

--- a/classes/hostname.bbclass
+++ b/classes/hostname.bbclass
@@ -1,0 +1,1 @@
+hostname = "openembedded-ros"

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,1 @@
+inherit hostname

--- a/recipes-core/netbase/netbase_%.bbappend
+++ b/recipes-core/netbase/netbase_%.bbappend
@@ -1,0 +1,6 @@
+do_install_prepend () {
+	sed -i -e "$ i\
+127.0.0.1	${hostname}.localdomain	${hostname}" ${WORKDIR}/hosts
+}
+
+inherit hostname


### PR DESCRIPTION
These commits set up the minimal network configuration for running roscore.
It might need further discussion if this shall be set up and provided in this application layer, or if it shall be only be provided in a separate layer for a simple image running ROS out-of-the-box, or only as documentation in this layer.
