### PR TITLE
roslaunch: Use as documented environment

### DIFF
--- a/recipes-ros/ros-comm/roslaunch/roscore-default
+++ b/recipes-ros/ros-comm/roslaunch/roscore-default
@@ -1,4 +1,7 @@
-ROS_ROOT=/usr
+ROS_ROOT=/opt/ros/hydro/
 ROS_PORT=11311
-ROS_MASTER_URI=http://localhost:$ROS_PORT
-CMAKE_PREFIX_PATH=$ROS_ROOT
+ROS_MASTER_URI=http://localhost:11311
+CMAKE_PREFIX_PATH=/opt/ros/hydro/
+PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin:/opt/ros/hydro/bin
+LD_LIBRARY_PATH=/opt/ros/hydro/lib
+PYTHONPATH=/opt/ros/hydro/lib/python2.7/site-packages

--- a/recipes-ros/ros-comm/roslaunch/roscore.service
+++ b/recipes-ros/ros-comm/roslaunch/roscore.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 EnvironmentFile=/etc/default/roscore
 ExecStartPre=/bin/touch ${CMAKE_PREFIX_PATH}/.catkin
-ExecStart=/usr/bin/roscore -p $ROS_PORT
+ExecStart=/opt/ros/hydro/bin/roscore -p $ROS_PORT
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
in relation to #307 

roscore-default: Removing not supported variable in variable
roscore-default: Adding PATH, LD_LIBRARY_PATH and PYTHONPATH
roscore.service: Using /opt/ros/hydro/bin instead of /usr/bin to launch
roscore

You can now install roslaunch-systemd :

opkg install roslaunch-systemd

and start roscore :

systemctl start roscore
