### PR TITLE
Generalize construction of ros_prefix and use it consistently

### DIFF
--- a/classes/ros.bbclass
+++ b/classes/ros.bbclass
@@ -7,8 +7,7 @@ ROS_BPN = "${@d.getVar('BPN', True).replace('-', '_')}"
 ROS_SPN ?= "${ROS_BPN}"
 ROS_SP = "${ROS_SPN}-${PV}"
 
-export ros_prefix = "/opt/ros/${ROSDISTRO}"
-ros_prefix_virtclass-native = "${STAGING_DIR_NATIVE}/opt/ros/${ROSDISTRO}"
+export ros_prefix = "${base_prefix}/opt/ros/${ROSDISTRO}"
 
 export ros_bindir = "${ros_prefix}/bin"
 export ros_libdir = "${ros_prefix}/${baselib}"

--- a/recipes-ros/catkin/catkin_0.5.89.bb
+++ b/recipes-ros/catkin/catkin_0.5.89.bb
@@ -14,13 +14,14 @@ SRC_URI += "file://0001-CATKIN_WORKSPACES-Don-t-require-.catkin-file.patch"
 inherit catkin
 
 FILES_${PN}-dev += "\
-    ${datadir}/eigen/cmake \
-    ${datadir}/ros/cmake \
-    ${prefix}/.catkin \
-    ${prefix}/.rosinstall \
-    ${prefix}/_setup_util.py \
-    ${prefix}/env.sh \
-    ${prefix}/setup.* \
+    ${ros_datadir}/eigen/cmake \
+    ${ros_datadir}/ros/cmake \
+    ${ros_datadir}/.catkin \
+    ${ros_prefix}/.catkin \
+    ${ros_prefix}/.rosinstall \
+    ${ros_prefix}/_setup_util.py \
+    ${ros_prefix}/env.sh \
+    ${ros_prefix}/setup.* \
     "
 
 RDEPENDS_${PN}_class-native = ""


### PR DESCRIPTION
The ros_prefix currently handled special situations like building a native package with a virtclass override. This can be handled more easily by basing the prefix on yocto's base prefix. This also sets the prefix correctly if one wants to build nativesdk packages.

Additionally the special ros_prefixes should be use in all ros packages to ensure the resulting packages contain all necessary assets.
