### PR TITLE
libpoco: compiling with arm64 architecture

### DIFF
--- a/recipes-extended/libpoco/libpoco/9258e482d71f327020efa10b873b9623458f2985.patch
+++ b/recipes-extended/libpoco/libpoco/9258e482d71f327020efa10b873b9623458f2985.patch
@@ -1,0 +1,24 @@
+From 9258e482d71f327020efa10b873b9623458f2985 Mon Sep 17 00:00:00 2001
+From: Aleksandar Fabijanic <alex@pocoproject.org>
+Date: Tue, 29 Jul 2014 10:46:52 -0500
+Subject: [PATCH] GH #508: Can't compile for arm64 architecture
+
+Upstream-Status: Backport [from version 1.5.4]
+---
+ Foundation/src/utils.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Foundation/src/utils.h b/Foundation/src/utils.h
+index dbd61a3..a25757c 100644
+--- a/Foundation/src/utils.h
++++ b/Foundation/src/utils.h
+@@ -59,7 +59,8 @@
+     defined(__mips__) || defined(__powerpc__) || \
+     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
+     defined(__SH4__) || defined(__alpha__) || \
+-    defined(_MIPS_ARCH_MIPS32R2)
++    defined(_MIPS_ARCH_MIPS32R2) || \
++    defined(__AARCH64EL__)
+ #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
+ #elif defined(_M_IX86) || defined(__i386__) || defined(__i386)
+ #if defined(_WIN32)

--- a/recipes-extended/libpoco/libpoco_1.5.3.bb
+++ b/recipes-extended/libpoco/libpoco_1.5.3.bb
@@ -9,6 +9,8 @@ SRC_URI = "https://github.com/pocoproject/poco/archive/poco-${PV}-release.tar.gz
 SRC_URI[md5sum] = "4636d84055a434fde3a67396bf15924a"
 SRC_URI[sha256sum] = "f26bbd7879ad79b45630f8efa20b1c65f0ddf81dc44f169245d512d208c71e53"
 
+SRC_URI += "file://9258e482d71f327020efa10b873b9623458f2985.patch"
+
 S = "${WORKDIR}/poco-poco-${PV}-release"
 
 EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release -DPOCO_UNBUNDLED=On"


### PR DESCRIPTION
During bitbaking core-image-ros-world for v0.2-rc1 release testing,
compiling libpoco for the qemuarm64 machine failed with:

  In file included from [...]/poco-poco-1.5.3-release/Foundation/src/diy-fp.h:31:0,
                   from [...]/poco-poco-1.5.3-release/Foundation/src/diy-fp.cc:29,
                   from [...]/poco-poco-1.5.3-release/Foundation/src/NumericString.cpp:23:
  [...]/poco-poco-1.5.3-release/Foundation/src/utils.h:72:2: error: #error Target architecture was not detected as supported by Double-Conversion.

This issue has been already been reported in the libpoco github issue
tracker [1] and has been resolved with a simple patch [2] in the libpoco
repository and libpoco releases since 1.5.4. Hence, this commit simply
adds this patch to the current libpoco recipe.

To address the libpoco issue, I also considered to update libpoco to
version 1.6.0. However, this was not possible as version 1.6.0 requires
CMake >= 3.0.0 and this would require updating cmake in
OpenEmbedded-Core, which has major impact on all layers. Also, updating
libpoco to 1.5.4 lead to a problem with the OpenEmbedded-Core-provided
pcre 1.5.36 and the POCO_UNBUNDLED setting during compilation:

  In file included from [...]/poco-poco-1.5.4-release/Foundation/src/RegularExpression.cpp:21:0:
  [...]/usr/include/pcre.h:325:26: error: conflicting declaration 'typedef struct real_pcre pcre'
  In file included from [...]/poco-poco-1.5.4-release/Foundation/src/RegularExpression.cpp:17:0:
  [...]/poco-poco-1.5.4-release/Foundation/include/Poco/RegularExpression.h:37:34: note: previous declaration as 'typedef struct real_pcre8_or_16 pcre'

This issue is probably caused by the commit 'PCRE 8.35.0 Update' [3],
which defines types from pcre 8.35 that are incompatible to pcre 8.36.

[1] https://github.com/pocoproject/poco/issues/508
[2] https://github.com/pocoproject/poco/commit/9258e482d71f327020efa10b873b9623458f2985.patch
[3] https://github.com/pocoproject/poco/commit/010f7a5370be450109f1726e39d5b193e63a6373.patch

Signed-off-by: Lukas Bulwahn lukas.bulwahn@oss.bmw-carit.de
