### PR TITLE
images: Remove spurious post-processing command

### DIFF
--- a/recipes-core/images/core-image-ros-roscore.bb
+++ b/recipes-core/images/core-image-ros-roscore.bb
@@ -10,7 +10,4 @@ inherit core-image
 
 IMAGE_ROOTFS_SIZE = "8192"
 
-# remove not needed ipkg informations
-ROOTFS_POSTPROCESS_COMMAND += "remove_packaging_data_files"
-
 IMAGE_INSTALL += "roslaunch"

--- a/recipes-core/images/core-image-ros-world.bb
+++ b/recipes-core/images/core-image-ros-world.bb
@@ -10,7 +10,4 @@ inherit core-image
 
 IMAGE_ROOTFS_SIZE = "8192"
 
-# remove not needed ipkg informations
-ROOTFS_POSTPROCESS_COMMAND += "remove_packaging_data_files"
-
 IMAGE_INSTALL += "packagegroup-ros-world"


### PR DESCRIPTION
As discussed [1], 'remove_packaging_data_files' generates a warning for
Poky version 1.5+ and is not needed.

[1] https://www.mail-archive.com/meta-ros%40googlegroups.com/msg00086.html

Signed-off-by: Ash Charles ashcharles@gmail.com
