### PR TITLE
Update from virtclass-native to class-native

### DIFF
--- a/classes/ros.bbclass
+++ b/classes/ros.bbclass
@@ -25,7 +25,7 @@ PREPROCESS_RELOCATE_DIRS += " \
 PKG_CONFIG_PATH .= ":${PKG_CONFIG_DIR}:${STAGING_DIR_HOST}${ros_libdir}/pkgconfig:${STAGING_DATADIR}/pkgconfig"
 PYTHON_SITEPACKAGES_DIR = "${ros_libdir}/${PYTHON_DIR}/site-packages"
 export PYTHONPATH = "${STAGING_DIR_NATIVE}${PYTHON_SITEPACKAGES_DIR}"
-PYTHONPATH_virtclass-native = "${PYTHON_SITEPACKAGES_DIR}"
+PYTHONPATH_class-native = "${PYTHON_SITEPACKAGES_DIR}"
 
 FILES_${PN} += "\
     ${ros_bindir}/* ${ros_libexecdir}/* ${ros_libdir}/lib*.so \

--- a/recipes-ros/catkin/catkin_0.5.90.bb
+++ b/recipes-ros/catkin/catkin_0.5.90.bb
@@ -1,6 +1,6 @@
 require catkin.inc
 
-DEPENDS_virtclass-native += "catkin-runtime"
+DEPENDS_class-native += "catkin-runtime"
 
 RDEPENDS_${PN}_class-native = ""
 RDEPENDS_${PN} = "cmake make binutils binutils-symlinks gcc gcc-symlinks g++ g++-symlinks \


### PR DESCRIPTION
As per Section 24.5.15 of the Yocto Manual [1], use of 'virtclass'
overrides has been deprecated since Yocto version 1.6. Update to
the new syntax.

[1] http://www.yoctoproject.org/docs/1.8/mega-manual/mega-manual.html

Signed-off-by: Ash Charles ashcharles@gmail.com
