### PR TITLE
robot-state-publisher: adjust to new dependencies

### DIFF
--- a/recipes-ros/robot-state-publisher/robot-state-publisher_1.11.0.bb
+++ b/recipes-ros/robot-state-publisher/robot-state-publisher_1.11.0.bb
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=18;endline=18;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "libeigen kdl-parser rosconsole roscpp rostime sensor-msgs tf tf-conversions"
+DEPENDS = "cmake-modules libeigen kdl-parser orocos-kdl rosconsole roscpp rostime sensor-msgs tf tf2-ros tf2-kdl"
 
 SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "424e1489a03e3c071b46f63f39b4c6d0"


### PR DESCRIPTION
The internal CI build detected that bitbake robot-state-publisher
fails after the recent version update. Hence, this commit adjusts
the dependencies to those dependencies stated in the package.xml.

Signed-off-by: Lukas Bulwahn lukas.bulwahn@oss.bmw-carit.de
