### PR TITLE
python-numpy: drop now superfluous bbappend file

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ Currently, this layer is still under continuous development.
 
   cv-bridge and dependent recipes, e.g., the image-transport recipes, depend on
   7568bfdd114597956a1da68746f207ec7f93a48d@openembedded-core.
-  
+  For native python-numpy support, these recipes also depend on
+  c13c5f40160d289bb62538a16900fed30621cb22@meta-openembedded or on
+  9bf355cceaec6ebacdcbcc35f9713ff73e1c85da@openembedded-core.
+
   Some recipes that need the Eigen library, e.g., the pcl-ros recipe, depend on
   424e3c1b930c0103c2cedfd4df1671e84a5256d5@meta-openembedded.
 

--- a/recipes-devtools/python/python-numpy_1.7.0.bbappend
+++ b/recipes-devtools/python/python-numpy_1.7.0.bbappend
@@ -1,1 +1,0 @@
-BBCLASSEXTEND = "native"


### PR DESCRIPTION
In the meta-ros commit b6080314 (commit date: 2013-11-17) [1], we
add python-numpy_1.7.0.bbappend to provide python-numpy as native
package, as the version update to cv-bridge 1.10.14 needs that.

Coincidentally, Ross Burton added native support to the
python-numpy recipe in the meta-openembedded commit c13c5f40
(commit date: 2013-11-18) [2]. However, the existing bbappend in
meta-ros was still required for use with releases before commit
c13c5f40.

On 2014-01-14, the python-numpy recipe was moved from meta-oe to
openembedded-core (commit a4415f89 and 9bf355cc [3, 4]).
Now, on 2015-12-16, the python-numpy recipe was updated to 1.10.1
(commit 3c3932f3 [5]), and hence, our version-specific bbappend
file fails to apply.

As the native package addition is now in the recipe for over two
years (commit date: 2013-11-18), and we assume all users to work on
versions where the change has been included, we simply drop our now
superfluous bbappend file.

[1] https://github.com/bmwcarit/meta-ros/commit/b6080314504be62c8fbfcb1d583e688448a2f023
[2] http://cgit.openembedded.org/meta-openembedded/commit/?id=c13c5f40160d289bb62538a16900fed30621cb22
[3] http://cgit.openembedded.org/meta-openembedded/commit/?id=a4415f89e533a59ba358f8575d56216d3650e59e
[4] http://cgit.openembedded.org/openembedded-core/commit/?id=9bf355cceaec6ebacdcbcc35f9713ff73e1c85da
[5] http://cgit.openembedded.org/openembedded-core/commit/?id=3c3932f3560c898e32287c8733b61180685ee539

Signed-off-by: Lukas Bulwahn lukas.bulwahn@oss.bmw-carit.de
