### PR TITLE
include contributions from pull request #364 properly

### DIFF
--- a/recipes-devtools/python/python-bson_0.4.1.bb
+++ b/recipes-devtools/python/python-bson_0.4.1.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "Independent BSON codec for Python that doesn't depend on MongoDB"
+SECTION = "devel"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=db7a1eab1d8b38da1e06abbf08d2498d"
+
+SRC_URI = "https://github.com/py-bson/bson/archive/${PV}.tar.gz;downloadfilename=py-bson_{PV}.tar.gz"
+SRC_URI[md5sum] = "9319364259c7b4eb77a218f7948f9fe8"
+SRC_URI[sha256sum] = "b84569685426374242dfc7d4fa08c9694951e85203d085c256866cf87dcb0b7e"
+
+S = "${WORKDIR}/bson-${PV}"
+
+inherit setuptools

--- a/recipes-devtools/python/python-pytz_2015.6.bb
+++ b/recipes-devtools/python/python-pytz_2015.6.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "Python Timezone Library"
+SECTION = "devel"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=22b38951eb857cf285a4560a914b7cd6"
+
+SRC_URI = "https://pypi.python.org/packages/source/p/pytz/pytz-${PV}.tar.gz;downloadfilename=pytz-{PV}.tar.gz"
+SRC_URI[md5sum] = "ff047a16dafeaa895bedef80a74c3728"
+SRC_URI[sha256sum] = "c598a6b6850dbcc00843651878e8282dac77c95e19d84847b6918eeb3ed8f0c2"
+
+S = "${WORKDIR}/pytz-${PV}"
+
+inherit setuptools

--- a/recipes-devtools/python/python-six_1.10.0.bb
+++ b/recipes-devtools/python/python-six_1.10.0.bb
@@ -1,0 +1,15 @@
+DESCRIPTION = "Six is a Python 2 and 3 compatibility library. It provides \
+  utility functions for smoothing over the differences between the Python \
+  versions with the goal of writing Python code that is compatible on both \
+  Python versions."
+SECTION = "devel"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=6f00d4a50713fa859858dd9abaa35b21"
+
+SRC_URI = "https://pypi.python.org/packages/source/s/six/six-${PV}.tar.gz;downloadfilename=six-{PV}.tar.gz"
+SRC_URI[md5sum] = "34eed507548117b2ab523ab14b2f8b55"
+SRC_URI[sha256sum] = "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+
+S = "${WORKDIR}/six-${PV}"
+
+inherit setuptools

--- a/recipes-ros/packagegroups/packagegroup-ros-world.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-world.bb
@@ -170,6 +170,11 @@ RDEPENDS_${PN} = "\
     ros-arduino-python \
     frontier-exploration \
     hector-mapping \
+    rosauth \
+    rosapi \
+    rosbridge-library \
+    rosbridge-server \
+    rosbridge-suite \
     "
 
 # joint-state-publisher still has some issues.

--- a/recipes-ros/rosauth/rosauth_0.1.7.bb
+++ b/recipes-ros/rosauth/rosauth_0.1.7.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "Server Side tools for Authorization and Autentication of ROS Clients"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp rostest"
+
+SRC_URI = "https://github.com/WPI-RAIL/rosauth/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "0e165e867239157266aa2e4c192244bf"
+SRC_URI[sha256sum] = "c85c4163c94d20bce9864180785210bfe3dfd110114f18212bd711d1be87c48e"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin

--- a/recipes-ros/rosbridge-suite/rosapi_0.7.13.bb
+++ b/recipes-ros/rosbridge-suite/rosapi_0.7.13.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "rosbridge provides a JSON interface to ROS, allowing any client to send JSON to publish or subscribe to ROS topics, call ROS services, and more"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "message-generation rospy rosservice"
+
+require rosbridge-suite.inc

--- a/recipes-ros/rosbridge-suite/rosbridge-library_0.7.13.bb
+++ b/recipes-ros/rosbridge-suite/rosbridge-library_0.7.13.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "rosbridge provides a JSON interface to ROS, allowing any client to send JSON to publish or subscribe to ROS topics, call ROS services, and more"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=68b329da9893e34099c7d8ad5cb9c940"
+
+DEPENDS = "message-generation std-msgs geometry-msgs rospy python-six python-bson python-pytz"
+
+require rosbridge-suite.inc

--- a/recipes-ros/rosbridge-suite/rosbridge-server_0.7.13.bb
+++ b/recipes-ros/rosbridge-suite/rosbridge-server_0.7.13.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "rosbridge provides a JSON interface to ROS, allowing any client to send JSON to publish or subscribe to ROS topics, call ROS services, and more"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=9add477069b61b5ccb4bac92ed431631"
+
+DEPENDS = "rosbridge-library rosapi rospy rosauth"
+
+require rosbridge-suite.inc

--- a/recipes-ros/rosbridge-suite/rosbridge-suite.inc
+++ b/recipes-ros/rosbridge-suite/rosbridge-suite.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/RobotWebTools/rosbridge_suite/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "710473c412c77a4d212478e2e1f6c678"
+SRC_URI[sha256sum] = "c26130590ed36d899dc4a2f3282caec96fadc75732cd5c3364e3210139d85820"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "rosbridge_suite"

--- a/recipes-ros/rosbridge-suite/rosbridge-suite_0.7.13.bb
+++ b/recipes-ros/rosbridge-suite/rosbridge-suite_0.7.13.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "rosbridge provides a JSON interface to ROS, allowing any client to send JSON to publish or subscribe to ROS topics, call ROS services, and more"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=67aef562572a41111c8c17f1079a2869"
+
+DEPENDS = "rosbridge-server rosbridge-library rosapi"
+
+require rosbridge-suite.inc


### PR DESCRIPTION
This commit adds recipes for rosbridge_suite and its dependencies.
Its main content is based on the commits of pull request #364 by
Christoph Schultz.

As maintainer, Lukas Bulwahn just included the contributions
with a proper commit message, added the new packages to the
packagegroup-ros-world, and slightly improved the line breaking.
