### PR TITLE
Redo of PR #371: Recipes for libccd, FCL, OMPL

### DIFF
--- a/recipes-extended/fcl/fcl/LICENSE
+++ b/recipes-extended/fcl/fcl/LICENSE
@@ -1,0 +1,32 @@
+Software License Agreement (BSD License)
+
+ Copyright (c) 2008-2014, Willow Garage, Inc.
+ Copyright (c) 2014-2015, Open Source Robotics Foundation
+ All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+  * Neither the name of Open Source Robotics Foundation nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.

--- a/recipes-extended/fcl/fcl_0.3.2.bb
+++ b/recipes-extended/fcl/fcl_0.3.2.bb
@@ -1,0 +1,25 @@
+DESCRIPTION = "FCL is a library for performing three types of proximity queries on a pair of geometric models composed of triangles and octrees."
+HOMEPAGE = "https://github.com/flexible-collision-library/fcl"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5823baab4b8de52197d0fb775e8fd4b7"
+
+# Octomap dependency not included as it is optional.
+DEPENDS = "boost libccd"
+
+SRC_URI = "https://github.com/flexible-collision-library/fcl/archive/${PV}.tar.gz"
+SRC_URI[md5sum] = "b12246df3f4e1d0768ce1e46a52900ff"
+SRC_URI[sha256sum] = "cf914f85b32cf8b63879907726df64e50da33f00d538759d789fe10fc5fbc95b"
+
+S = "${WORKDIR}/fcl-${PV}"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://LICENSE;subdir=fcl-${PV}"
+
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
+FILES_${PN} += "${libdir}/libfcl.so"
+
+# Need to override this, otherwise libfcl.so is included in dev packageW.
+FILES_${PN}-dev = "${includedir} ${libdir}/pkgconfig"
+
+inherit pkgconfig cmake

--- a/recipes-extended/libccd/libccd_1.5.0.bb
+++ b/recipes-extended/libccd/libccd_1.5.0.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "libccd is library for a collision detection between two convex shapes."
+HOMEPAGE = "https://github.com/danfis/libccd"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://BSD-LICENSE;md5=ff7a32175d897961df3eec70a6166429"
+
+SRC_URI = "http://libccd.danfis.cz/files/libccd-1.5.tar.gz"
+SRC_URI[md5sum] = "461a8d57a7899074e197a8f0c05ed38e"
+SRC_URI[sha256sum] = "676f937193090579ecddc5075adbcd963e3001d4ea4dc16b163031f50bc16130"
+
+S = "${WORKDIR}/libccd-1.5"
+
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release -DCCD_DOUBLE=1"
+
+inherit pkgconfig cmake

--- a/recipes-extended/ompl/ompl_1.1.0.bb
+++ b/recipes-extended/ompl/ompl_1.1.0.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "The Open Motion Planning Library (OMPL) consists of a set of sampling-based motion planning algorithms."
+HOMEPAGE = "http://ompl.kavrakilab.org/"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=923f436234988118e9a042c42a64323c"
+
+DEPENDS = "boost libeigen"
+
+SRC_URI = "https://bitbucket.org/ompl/ompl/downloads/ompl-1.1.0-Source.tar.gz"
+SRC_URI[md5sum] = "2a72c5add9675e164c8370a710627e93"
+SRC_URI[sha256sum] = "4d141ad3aa322c65ee7ecfa90017a44a8114955316e159b635fae5b5e7db74f8"
+
+S = "${WORKDIR}/ompl-${PV}-Source"
+
+inherit cmake


### PR DESCRIPTION
Cleaner version of PR #371 
- OpenNI2 recipe has been removed as currently assumes ARM architecture.
- FCL LICENSE file is required as it includes some notes about the copyright (it is the [same file](https://github.com/flexible-collision-library/fcl/blob/master/LICENSE) as in the original repo
