### PR TITLE
bfl: patch to obtain pkgconfig sanity

### DIFF
--- a/recipes-extended/bfl/bfl/0001-drop-pathes-to-unused-libraries-for-passing-the-qa_s.patch
+++ b/recipes-extended/bfl/bfl/0001-drop-pathes-to-unused-libraries-for-passing-the-qa_s.patch
@@ -1,0 +1,28 @@
+From 382f7de16cc13b6604e77ca5903c844c513277cc Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
+Date: Sat, 6 Feb 2016 18:10:24 +0100
+Subject: [PATCH] drop pathes to unused libraries for passing the qa_staging
+ pkgconfig sanity check
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
+---
+ orocos-bfl.pc.in | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/orocos-bfl.pc.in b/orocos-bfl.pc.in
+index c1efd60..8e32035 100644
+--- a/orocos-bfl.pc.in
++++ b/orocos-bfl.pc.in
+@@ -5,5 +5,5 @@ includedir=${prefix}/include/bfl
+ Name: orocos-bfl
+ Description: Orocos Bayesian Filtering Library
+ Version: @VERSION@
+-Libs: -L${libdir} -lorocos-bfl @MATRIX_LIBS@ @RNG_LIBS@ @GINAC_LIBS@
+-Cflags: -I${includedir} -I@MATRIX_INCLUDE@ -I@RNG_INCLUDE@ -I@GINAC_INCLUDE@
++Libs: -L${libdir} -lorocos-bfl
++Cflags: -I${includedir}
+-- 
+2.4.3
+

--- a/recipes-extended/bfl/bfl_0.7.0-6.bb
+++ b/recipes-extended/bfl/bfl_0.7.0-6.bb
@@ -9,6 +9,8 @@ SRC_URI = "https://github.com/ros-gbp/${PN}-release/archive/release/indigo/${PN}
 SRC_URI[md5sum] = "8140555e28ddea22a10a9ec59d96a4a0"
 SRC_URI[sha256sum] = "296bec7f11430dd99a9617333d91c5c94ccf96ef6a4aa242917cc19480169740"
 
+SRC_URI += "file://0001-drop-pathes-to-unused-libraries-for-passing-the-qa_s.patch"
+
 S = "${WORKDIR}/bfl-release-release-indigo-${P}"
 
 inherit cmake faulty-solibs


### PR DESCRIPTION
Since 3739aaf644d5a0f28e85fd07c67cecbfa5b8fb8a on openembedded-core,
the build of the bfl recipe fails with:

  ERROR: QA Issue: orocos-bfl.pc failed sanity test (tmpdir) in path /[...]/bfl/0.7.0-6-r0/sysroot-destdir//usr/lib/pkgconfig [pkgconfig]
  ERROR: QA Issue: bfl.pc failed sanity test (tmpdir) in path /[...]/bfl/0.7.0-6-r0/sysroot-destdir//usr/lib/pkgconfig [pkgconfig]
  ERROR: QA staging was broken by the package built above
  ERROR: Function failed: do_qa_staging
  ERROR: Logfile of failure stored in: /[...]/bfl/0.7.0-6-r0/temp/log.do_populate_sysroot.12063
  ERROR: Task 4361 (/[...]/meta-ros/recipes-extended/bfl/bfl_0.7.0-6.bb, do_populate_sysroot) failed with exit code '1'

The openembedded-core recipe suggests that the bfl recipe was broken
since its initial commit, but it remained unnoticed. This commit now
adds a patch to drop the unneeded and wrong paths from the pkgconfig
file.

Signed-off-by: Lukas Bulwahn lukas.bulwahn@oss.bmw-carit.de
