### PR TITLE
rename repository 'geometry_experimental' to 'geometry2'

### DIFF
--- a/recipes-ros/geometry-experimental/geometry-experimental.inc
+++ b/recipes-ros/geometry-experimental/geometry-experimental.inc
@@ -1,9 +1,0 @@
-SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
-SRC_URI[md5sum] = "c2d1473770d47d5f3354e183b3defb6a"
-SRC_URI[sha256sum] = "430115ef4a3352e8b00596ff7406e6cb14fc1720250cf164754cf724c7f371c3"
-
-S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
-
-inherit catkin
-
-ROS_SPN = "geometry_experimental"

--- a/recipes-ros/geometry2/geometry2.inc
+++ b/recipes-ros/geometry2/geometry2.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "063484906d1c2f1a4ee961680e43b559"
+SRC_URI[sha256sum] = "011b77bc33afea927bab2707ddda585df8de5f1fc6e387081f6bf1ea12d2323b"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "geometry2"

--- a/recipes-ros/geometry2/tf2-geometry-msgs_0.5.12.bb
+++ b/recipes-ros/geometry2/tf2-geometry-msgs_0.5.12.bb
@@ -5,4 +5,4 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc
 
 DEPENDS = "actionlib-msgs geometry-msgs tf2-ros tf2 orocos-kdl"
 
-require geometry-experimental.inc
+require geometry2.inc

--- a/recipes-ros/geometry2/tf2-kdl_0.5.12.bb
+++ b/recipes-ros/geometry2/tf2-kdl_0.5.12.bb
@@ -5,4 +5,4 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc
 
 DEPENDS = "libeigen orocos-kdl tf2 tf2-ros"
 
-require geometry-experimental.inc
+require geometry2.inc

--- a/recipes-ros/geometry2/tf2-msgs_0.5.12.bb
+++ b/recipes-ros/geometry2/tf2-msgs_0.5.12.bb
@@ -5,4 +5,4 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9de
 
 DEPENDS = "actionlib-msgs geometry-msgs"
 
-require geometry-experimental.inc
+require geometry2.inc

--- a/recipes-ros/geometry2/tf2-py_0.5.12.bb
+++ b/recipes-ros/geometry2/tf2-py_0.5.12.bb
@@ -9,4 +9,4 @@ EXTRA_OECMAKE += "\
     -DCMAKE_SKIP_RPATH=ON \
     "
 
-require geometry-experimental.inc
+require geometry2.inc

--- a/recipes-ros/geometry2/tf2-ros_0.5.12.bb
+++ b/recipes-ros/geometry2/tf2-ros_0.5.12.bb
@@ -5,4 +5,4 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9de
 
 DEPENDS = "actionlib message-filters rosgraph tf2 tf2-py"
 
-require geometry-experimental.inc
+require geometry2.inc

--- a/recipes-ros/geometry2/tf2-sensor-msgs_0.5.12.bb
+++ b/recipes-ros/geometry2/tf2-sensor-msgs_0.5.12.bb
@@ -5,4 +5,4 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc
 
 DEPENDS = "cmake-modules libeigen sensor-msgs tf2-ros tf2"
 
-require geometry-experimental.inc
+require geometry2.inc

--- a/recipes-ros/geometry2/tf2-tools_0.5.12.bb
+++ b/recipes-ros/geometry2/tf2-tools_0.5.12.bb
@@ -5,4 +5,4 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc
 
 DEPENDS = "tf2-msgs tf2 tf2-ros"
 
-require geometry-experimental.inc
+require geometry2.inc

--- a/recipes-ros/geometry2/tf2_0.5.12.bb
+++ b/recipes-ros/geometry2/tf2_0.5.12.bb
@@ -6,4 +6,4 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=16;endline=16;md5=d566ef916e9de
 
 DEPENDS = "tf2-msgs geometry-msgs console-bridge rospy"
 
-require geometry-experimental.inc
+require geometry2.inc


### PR DESCRIPTION
The repository `geometry_experimental` has been moved to [geometry2](https://github.com/ros/geometry2)
