### PR TITLE
Drop obsolete call to sysroot_stage_libdir

### DIFF
--- a/classes/ros.bbclass
+++ b/classes/ros.bbclass
@@ -71,7 +71,7 @@ ros_sysroot_preprocess () {
         sysroot_stage_dir ${D}${ros_sysconfdir} ${SYSROOT_DESTDIR}${ros_sysconfdir}
     fi
     if [ -d ${D}${ros_libdir} ]; then
-        sysroot_stage_libdir ${D}${ros_libdir} ${SYSROOT_DESTDIR}${ros_libdir}
+        sysroot_stage_dir ${D}${ros_libdir} ${SYSROOT_DESTDIR}${ros_libdir}
     fi
     sysroot_stage_dir ${D}${ros_datadir} ${SYSROOT_DESTDIR}${ros_datadir}
     if [ -d ${D}${ros_stacksdir} ]; then


### PR DESCRIPTION
It replaces the sysroot_stage_libdir() call as it is no longer available (it was just a wrapper for sysroot_stage_dir() anyway).

Please see: https://github.com/openembedded/openembedded-core/commit/80e7e7f78d957b8159bede2a5cd5614d8d73039c
