### PR TITLE
catkin: patch _setup_util.py.in to address #384

### DIFF
--- a/recipes-ros/catkin/catkin.inc
+++ b/recipes-ros/catkin/catkin.inc
@@ -9,8 +9,11 @@ SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilena
 SRC_URI[md5sum] = "66f89dd5f7dbeb1662ff32890acabd70"
 SRC_URI[sha256sum] = "2cb7efdaecc238a156929861645c5cfd96977a8606fb7765e131304072d1c82c"
 
-SRC_URI += "file://0001-CATKIN_WORKSPACES-Don-t-require-.catkin-file.patch\
-            file://0002-PKG_CONFIG_LIB_PATHS-use-cmake-root-path.patch"
+SRC_URI += "\
+    file://0001-CATKIN_WORKSPACES-Don-t-require-.catkin-file.patch \
+    file://0002-PKG_CONFIG_LIB_PATHS-use-cmake-root-path.patch \
+    file://0001-use-python-provided-by-environment-instead-of-the-ge.patch \
+    "
 
 inherit catkin
 

--- a/recipes-ros/catkin/files/0001-use-python-provided-by-environment-instead-of-the-ge.patch
+++ b/recipes-ros/catkin/files/0001-use-python-provided-by-environment-instead-of-the-ge.patch
@@ -1,0 +1,32 @@
+From 431739f10027022b6e3d2cd75cffa04c848cd14d Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@bmw-carit.de>
+Date: Tue, 31 May 2016 15:38:05 +0200
+Subject: [PATCH] use python provided by environment instead of the generated
+ one
+
+The catkin developers changed the cmake-generated template _setup_util.py
+to use @PYTHON_EXECUTABLE@ instead of /usr/bin/env python in changeset
+bf12b40c2 [1]. We revert this change here to address the issue #384 [2].
+
+[1] https://github.com/ros/catkin/commit/bf12b40c2a93b11c3666619a474d35bcfea20837
+[2] https://github.com/bmwcarit/meta-ros/issues/384
+
+Upstream-Status: Inappropriate [only for our setup]
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
+---
+ cmake/templates/_setup_util.py.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/templates/_setup_util.py.in b/cmake/templates/_setup_util.py.in
+index cace21c..ff2c6b4 100755
+--- a/cmake/templates/_setup_util.py.in
++++ b/cmake/templates/_setup_util.py.in
+@@ -1,4 +1,4 @@
+-#!@PYTHON_EXECUTABLE@
++#!/usr/bin/env python
+ # -*- coding: utf-8 -*-
+ 
+ # Software License Agreement (BSD License)
+-- 
+1.9.1
+


### PR DESCRIPTION
In _setup_util.py.in, we use python provided by environment instead of
the generated one, as the generated python path can be arbitrarily long
(depending on the location of the build directory), and hence reaches
the shebang line limit, causing the script to fail at start-up.

The catkin developers changed the cmake-generated template _setup_util.py
to use @PYTHON_EXECUTABLE@ instead of /usr/bin/env python in changeset
bf12b40c2 [1]. We revert this change here to address the issue #384 [2].

[1] https://github.com/ros/catkin/commit/bf12b40c2a93b11c3666619a474d35bcfea20837
[2] https://github.com/bmwcarit/meta-ros/issues/384

Signed-off-by: Lukas Bulwahn lukas.bulwahn@oss.bmw-carit.de
