### PR TITLE
adjust some LIC_FILES_CHKSUM retroactively to version update

### DIFF
--- a/recipes-ros/image-pipeline/camera-calibration_1.12.16.bb
+++ b/recipes-ros/image-pipeline/camera-calibration_1.12.16.bb
@@ -2,6 +2,6 @@ DESCRIPTION = "camera_calibration allows easy calibration of monocular or stereo
 checkerboard calibration target."
 SECTION = "devel"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=24;endline=24;md5=d566ef916e9dedc494f5f793a6690ba5"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=23;endline=23;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 require image-pipeline.inc

--- a/recipes-ros/pluginlib/pluginlib_1.10.2.bb
+++ b/recipes-ros/pluginlib/pluginlib_1.10.2.bb
@@ -1,8 +1,8 @@
 DESCRIPTION = "The pluginlib package provides tools for writing and dynamically loading plugins \
 using the ROS build infrastructure."
 SECTION = "devel"
-LICENSE = "BSD & BSL-1.0"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=10;md5=bbbb6ab628b1f3daee74dd9c62bee312"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 DEPENDS = "boost class-loader rosconsole roslib libtinyxml"
 

--- a/recipes-ros/robot-model/collada-parser_1.11.10.bb
+++ b/recipes-ros/robot-model/collada-parser_1.11.10.bb
@@ -5,7 +5,7 @@ parser when working with Collada robot descriptions, the preferred user \
 API is found in the urdf package."
 SECTION = "devel"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=15;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 DEPENDS = "collada-dom roscpp urdfdom-headers urdf-parser-plugin class-loader"
 

--- a/recipes-ros/robot-model/collada-urdf_1.11.10.bb
+++ b/recipes-ros/robot-model/collada-urdf_1.11.10.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "This package contains a tool to convert Unified Robot Description
 documents into COLLAborative Design Activity (COLLADA) documents."
 SECTION = "devel"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=15;md5=d566ef916e9dedc494f5f793a6690ba5"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=16;endline=16;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 DEPENDS = "angles assimp resource-retriever collada-dom collada-parser roscpp urdf geometric-shapes tf"
 

--- a/recipes-ros/robot-model/kdl-parser_1.11.10.bb
+++ b/recipes-ros/robot-model/kdl-parser_1.11.10.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "The Kinematics and Dynamics Library (KDL) defines a tree structure to represent the kinematic and dynamic parameters of a robot mechanism. kdl_parser provides tools to construct a KDL tree from an XML robot representation in URDF."
 SECTION = "devel"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=15;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 DEPENDS = "libeigen orocos-kdl rosconsole roscpp urdf cmake-modules"
 

--- a/recipes-ros/robot-model/urdf-parser-plugin_1.11.10.bb
+++ b/recipes-ros/robot-model/urdf-parser-plugin_1.11.10.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "This package contains a C++ base class for URDF parsers"
 SECTION = "devel"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 DEPENDS = "urdfdom-headers"
 

--- a/recipes-ros/robot-model/urdf_1.11.10.bb
+++ b/recipes-ros/robot-model/urdf_1.11.10.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "This package contains a C++ parser for the Unified Robot Description Format (URDF), which is an XML format for representing a robot model. The code API of the parser has been through our review process and will remain backwards compatible in future releases."
 SECTION = "devel"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=15;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 DEPENDS = "rosconsole-bridge roscpp urdfdom-headers urdf-parser-plugin pluginlib urdfdom cmake-modules libtinyxml"
 


### PR DESCRIPTION
After the version updates of recipes, I re-ran a successful build of all packages (bitbake core-image-ros-world) without a clean build. Due to some strange reason, the license check of the updated packages was skipped on the non-clean build. Some days later, i re-ran on a clean build and noticed that license files were updated. These commit address this issue.
