### PR TITLE
urdfdom-headers: Allow empty package to be created

### DIFF
--- a/recipes-ros/urdfdom-headers/urdfdom-headers_0.3.0.bb
+++ b/recipes-ros/urdfdom-headers/urdfdom-headers_0.3.0.bb
@@ -11,3 +11,5 @@ SRC_URI[sha256sum] = "f059350cd85fc3b8394ed0c3bd0d4b8d14fa9c8edd09c3ee01881b4711
 S = "${WORKDIR}/${ROS_SP}"
 
 inherit cmake ros faulty-solibs
+
+ALLOW_EMPTY_${PN} = "1"


### PR DESCRIPTION
Short:
Solves bitbake dependency error when IMAGE_FEATURES += " dev-pkgs " is set

Long:
urdfdom-headers are only headers so bitbake packages them all into
urdfdom-headers-dev. Since there are no files to be packaged into
urdfdom-headers then it doesn't create the package. urdfdom-headers is a dependency
of urdfdom-headers-dev by default so bitbake errors when building an image
with dev-pkgs enabled.
