### PR TITLE
octomap-ros: solves link issue with liboctomap.so and local ros installation

### DIFF
--- a/recipes-ros/octomap-ros/octomap-ros_0.4.0.bb
+++ b/recipes-ros/octomap-ros/octomap-ros_0.4.0.bb
@@ -17,4 +17,5 @@ do_configure_append() {
     sed -i -e 's: /usr/lib/liboctomap.so: ${STAGING_LIBDIR}/liboctomap.so:g' \
         -e 's: /usr/lib/liboctomath.so: ${STAGING_LIBDIR}/liboctomath.so:g' \
         ${B}/CMakeFiles/octomap_ros.dir/build.make
+    sed -i -e 's:-L\/opt\/ros\/indigo\/lib::g' ${B}/CMakeFiles/octomap_ros.dir/link.txt
 }


### PR DESCRIPTION
Somehow when compiling octomap-ros and collada-urdf packages, there's an include to /opt/ros/indigo/lib

[ 50%] Linking CXX executable devel/lib/collada_urdf/collada_to_urdf

/home/yocto/poky/build/tmp/sysroots/x86_64-linux/usr/bin/cmake -E cmake_link_script CMakeFiles/collada_to_urdf.dir/link.txt --verbose=1

/home/yocto/poky/build/tmp/sysroots/x86_64-linux/usr/bin/arm-poky-linux-gnueabi/arm-poky-linux-gnueabi-g++    -march=armv7-a -marm  -mthumb-interwork -mfloat-abi=hard -mfpu=neon-vfpv4 -mtune=cortex-a7  --sysroot=/home/yocto/poky/build/tmp/sysroots/raspberrypi3  -O2 -pipe -g -feliminate-unused-debug-types -fvisibility-inlines-hidden  -march=armv7-a -marm  -mthumb-interwork -mfloat-abi=hard -mfpu=neon-vfpv4 -mtune=cortex-a7  --sysroot=/home/yocto/poky/build/tmp/sysroots/raspberrypi3  -O2 -pipe -g -feliminate-unused-debug-types -fvisibility-inlines-hidden -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed  -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed CMakeFiles/collada_to_urdf.dir/src/collada_to_urdf.cpp.o  -o devel/lib/collada_urdf/collada_to_urdf  **-L/opt/ros/indigo/lib** -rdynamic -lassimp /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libcollada_parser.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libresource_retriever.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/liburdf.so -lurdfdom_sensor -lurdfdom_model_state -lurdfdom_model -lurdfdom_world /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/librosconsole_bridge.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libgeometric_shapes.so -loctomap -loctomath /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/librandom_numbers.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libtf.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libtf2_ros.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libactionlib.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libmessage_filters.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libroscpp.so -lpthread -lboost_signals-mt -lboost_filesystem-mt /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libxmlrpcpp.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libtf2.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libroscpp_serialization.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/librosconsole.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/librosconsole_log4cxx.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/librosconsole_backend_interface.so -llog4cxx -lboost_regex-mt /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/librostime.so -lboost_date_time-mt /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libcpp_common.so -lboost_system-mt -lboost_thread-mt -lconsole_bridge -lcollada-dom2.4-dp -lboost_system-mt -lboost_filesystem-mt -lboost_program_options-mt /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libxmlrpcpp.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libtf2.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libroscpp_serialization.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/librosconsole.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/librosconsole_log4cxx.so /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/librosconsole_backend_interface.so -llog4cxx -lboost_regex-mt /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/librostime.so -lboost_date_time-mt /home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib/libcpp_common.so -lboost_thread-mt -lconsole_bridge -lcollada-dom2.4-dp -lboost_program_options-mt -Wl,-rpath,/home/yocto/poky/build/tmp/sysroots/raspberrypi3/opt/ros/indigo/lib:/opt/ros/indigo/lib: 

**/opt/ros/indigo/lib/liboctomap.so: file not recognized: File format not recognized**
collect2: error: ld returned 1 exit status

Doing _sudo apt-get remove --purge ros-indigo-octomap_ solved the issue but no one wants to do so

I found out it could be solved removing this string from the link.txt file
