### PR TITLE
python-imaging: adds a patch to disable link to host tcl lib Fixes #395

### DIFF
--- a/recipes-devtools/python/python-imaging/disable-link-to-host-tcl-lib.patch
+++ b/recipes-devtools/python/python-imaging/disable-link-to-host-tcl-lib.patch
@@ -1,0 +1,22 @@
+Those lines link python-imaging to host tcl.
+
+Signed-off-by: David Bensoussan <david.bensoussan.job@gmail.com>
+
+diff -uNr a/setup.py b/setup.py
+--- a/setup.py  2016-09-18 08:18:43.507521296 +0000
++++ b/setup.py  2016-09-18 08:18:32.635521296 +0000
+@@ -207,10 +207,10 @@
+         # add standard directories
+ 
+         # look for tcl specific subdirectory (e.g debian)
+-        if _tkinter:
+-            tcl_dir = "/usr/include/tcl" + TCL_VERSION
+-            if os.path.isfile(os.path.join(tcl_dir, "tk.h")):
+-                add_directory(include_dirs, tcl_dir)
++#        if _tkinter:
++#            tcl_dir = "/usr/include/tcl" + TCL_VERSION
++#            if os.path.isfile(os.path.join(tcl_dir, "tk.h")):
++#                add_directory(include_dirs, tcl_dir)
+ 
+         #
+         # insert new dirs *before* default libs, to avoid conflicts

--- a/recipes-devtools/python/python-imaging_1.1.7.bb
+++ b/recipes-devtools/python/python-imaging_1.1.7.bb
@@ -9,7 +9,9 @@ PR = "r5"
 SRC_URI = "http://effbot.org/downloads/Imaging-${PV}.tar.gz \
            file://0001-python-imaging-setup.py-force-paths-for-zlib-freetyp.patch \
            file://allow.to.disable.some.features.patch \
-           file://fix-freetype-includes.patch"
+           file://fix-freetype-includes.patch \
+           file://disable-link-to-host-tcl-lib.patch \
+"
 
 SRC_URI[md5sum] = "fc14a54e1ce02a0225be8854bfba478e"
 SRC_URI[sha256sum] = "895bc7c2498c8e1f9b99938f1a40dc86b3f149741f105cf7c7bd2e0725405211"


### PR DESCRIPTION
Everything's in the title
