### PR TITLE
python-rosdistro: add missing lib rosep2 depends on

### DIFF
--- a/recipes-devtools/python/python-rosdep_0.11.5.bb
+++ b/recipes-devtools/python/python-rosdep_0.11.5.bb
@@ -12,7 +12,7 @@ SRC_URI[sha256sum] = "46e072074270a1ea25411829814f4bdc1f34b358c950e9b8a7b75b4a40
 
 S = "${WORKDIR}/${SRCNAME}-${PV}"
 
-RDEPENDS_${PN} += "python-catkin-pkg python-rospkg python-pyyaml python-netclient"
+RDEPENDS_${PN} += "python-catkin-pkg python-rospkg python-pyyaml python-netclient python-rosdistro"
 
 inherit setuptools
 

--- a/recipes-devtools/python/python-rosdistro_0.4.7.bb
+++ b/recipes-devtools/python/python-rosdistro_0.4.7.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "ROS package library"
+SECTION = "devel/python"
+LICENSE = "BSD & MIT"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=48623a4c0f1b1f65fae1dedd990a7f54"
+SRCNAME = "rosdistro"
+
+SRC_URI = "http://download.ros.org/downloads/rosdistro/rosdistro-${PV}.tar.gz"
+SRC_URI[md5sum] = "a699690fab755fd1b92b2ac04933e227"
+SRC_URI[sha256sum] = "f44757336bcee4089f6f6d570248e7c4e09eebfe5238d6ae60d8bd35361eedc4"
+
+S = "${WORKDIR}/${SRCNAME}-${PV}"
+
+RDEPENDS_${PN} += "python-pyyaml"
+
+inherit setuptools
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
roswtf reports uninitialized /etc/ros structure and recommends
to fix the issue by running `rosdep init`. But rosdep throws an
exception when trying to import the missing rosdistro library.

The library is supposed to be dropped in kinetic, but it's still
needed in indigo which the layer is based on at the moment.
So, the patch adds the library to the layer.

Signed-off-by: Dmitry Rozhkov dmitry.rozhkov@linux.intel.com
