### PR TITLE
realsense-camera: support RealSense camera

### DIFF
--- a/recipes-extended/librealsense/librealsense/0001-Fix-detection-of-ROS-build.patch
+++ b/recipes-extended/librealsense/librealsense/0001-Fix-detection-of-ROS-build.patch
@@ -1,0 +1,35 @@
+From e036c870bca711ef419f6942df125b20d988353c Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Fri, 9 Dec 2016 16:10:21 +0200
+Subject: [PATCH] Fix detection of ROS build
+
+CMAKE_PREFIX_PATH is not an environment variable, but CMake's
+internal one that contains a list of items (strings). This
+list needs to be concattenated into a single string in order
+to become "match"-able against a regex.
+
+Upstream-Status: Submitted [https://github.com/IntelRealSense/librealsense/pull/387]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8772f10..44295ee 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,8 +3,8 @@
+ # ubuntu 16.04 LTS cmake version 3.5.1
+ cmake_minimum_required(VERSION 2.8.3)
+ 
+-IF(DEFINED ENV{CMAKE_PREFIX_PATH})
+-  IF($ENV{CMAKE_PREFIX_PATH} MATCHES "/opt/ros")
++IF(DEFINED CMAKE_PREFIX_PATH)
++  IF("${CMAKE_PREFIX_PATH}" MATCHES "/opt/ros")
+     set(ROS_BUILD_TYPE TRUE)
+   ENDIF()
+ ENDIF()
+-- 
+2.7.4
+

--- a/recipes-extended/librealsense/librealsense_1.11.2.bb
+++ b/recipes-extended/librealsense/librealsense_1.11.2.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "Cross-platform camera capture for Intel® RealSense™ F200, SR300 and R200"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+SRC_URI = "https://github.com/IntelRealSense/librealsense/archive/v${PV}.tar.gz \
+           file://0001-Fix-detection-of-ROS-build.patch \
+           "
+SRC_URI[md5sum] = "27ce627c02731623c23894baeb73b2b1"
+
+DEPENDS = "libusb1"
+
+inherit catkin

--- a/recipes-extended/realsense-camera/realsense-camera/0001-realsense-camera-don-t-ignore-linker-flags-set-by-us.patch
+++ b/recipes-extended/realsense-camera/realsense-camera/0001-realsense-camera-don-t-ignore-linker-flags-set-by-us.patch
@@ -1,0 +1,37 @@
+From 6eac973eb36a6f10dd7278b6bc3798a216e52e16 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Mon, 12 Dec 2016 11:11:58 +0200
+Subject: [PATCH] realsense-camera: don't ignore linker flags set by user
+
+Yocto's bitbake sets global LDFLAGS that include the option
+--hash-style=gnu. If this option is ignored then bitbake's
+QA checks report that
+
+QA Issue: No GNU_HASH in the elf binary: '/[...]/opt/ros/indigo/lib/librealsense_camera_nodelet.so' [ldflags]
+
+The patch includes user defined linker flags to
+CMAKE_SHARED_LINKER_FLAGS defined in the project's CMakeList.txt.
+
+Upstream-Status: Submitted [https://github.com/intel-ros/realsense/pull/162]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ realsense_camera/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c5cfffe..307fd97 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,7 +12,7 @@ set(CMAKE_CXX_FLAGS "-fPIE -fPIC -std=c++11 -O2 -D_FORTIFY_SOURCE=2 -fstack-prot
+ # Flags executables
+ set(CMAKE_EXE_LINKER_FLAGS "-pie -z noexecstack -z relro -z now")
+ # Flags shared libraries
+-set(CMAKE_SHARED_LINKER_FLAGS "-z noexecstack -z relro -z now")
++set(CMAKE_SHARED_LINKER_FLAGS "-z noexecstack -z relro -z now ${CMAKE_SHARED_LINKER_FLAGS}")
+ 
+ find_package(catkin REQUIRED COMPONENTS
+   librealsense
+-- 
+2.7.4
+

--- a/recipes-extended/realsense-camera/realsense-camera_1.6.1.bb
+++ b/recipes-extended/realsense-camera/realsense-camera_1.6.1.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "ROS driver for RealSense camera"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=4bcd5f0e140091c68f8c0bcfdd6181e0"
+
+DEPENDS = "librealsense cv-bridge camera-info-manager pcl-ros roscpp"
+
+SRC_URI = "https://github.com/intel-ros/realsense/archive/${PV}.tar.gz \
+           file://0001-realsense-camera-don-t-ignore-linker-flags-set-by-us.patch \
+           "
+SRC_URI[md5sum] = "4adab9a45a0b7a84cd28f1de538d0de8"
+
+S = "${WORKDIR}/realsense-${PV}/realsense_camera"
+
+inherit catkin


### PR DESCRIPTION
This is rather a request for comments on adding the RealSense camera driver for ROS to the layer. In my opinion the main challenge of such addition is that meta-ros has to depend on one more layer.
If that's unacceptable what would be a better way to integrate RealSense support to meta-ros?