### PR TITLE
Add recipes for mavros

### DIFF
--- a/recipes-ros/mavros/libmavconn_0.17.4.bb
+++ b/recipes-ros/mavros/libmavconn_0.17.4.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "MAVLink communication library"
+LICENSE = "BSD | GPLv3 | LGPLv3"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=17;md5=9b511d4c606b1a23e454d3260818d003"
+
+DEPENDS = " \
+    boost \
+    ros-mavlink \
+    console-bridge \
+"
+
+RDEPENDS_${PN} = " \
+    boost \
+    ros-mavlink \
+    console-bridge \
+"
+
+require mavros.inc
+
+ROS_PKG_SUBDIR = "libmavconn"

--- a/recipes-ros/mavros/mavros-extras_0.17.4.bb
+++ b/recipes-ros/mavros/mavros-extras_0.17.4.bb
@@ -1,0 +1,32 @@
+DESCRIPTION = "Extra nodes and plugins for <a href="http://wiki.rot.org/mavros">MAVROS</a>"
+
+LICENSE = "BSD | GPLv3 | LGPLv3"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=14;md5=5e724d80140fc99e7507c9876e320175"
+
+MAVROS_RUN_AND_BUILD_DEPENDS = " \
+     roscpp \
+     tf2-ros \
+     tf \
+     geometry-msgs \
+     mavros-msgs \
+     sensor-msgs \
+     std-msgs \
+     visualization-msgs \
+     urdf \
+     image-transport \
+     mavros \
+ "
+
+DEPENDS = "\
+    cmake-modules \
+    cv-bridge \
+    ${MAVROS_RUN_AND_BUILD_DEPENDS} \
+"
+
+RDEPENDS_${PN} = "\
+    ${MAVROS_RUN_AND_BUILD_DEPENDS} \ 
+"
+
+require mavros.inc
+
+ROS_PKG_SUBDIR = "mavros_extras"

--- a/recipes-ros/mavros/mavros-msgs_0.17.4.bb
+++ b/recipes-ros/mavros/mavros-msgs_0.17.4.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "mavros_msgs defines messages for MAVROS"
+LICENSE = "BSD | GPLv3 | LGPLv3"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=13;md5=9b511d4c606b1a23e454d3260818d003"
+
+DEPENDS = " \
+    message-generation \
+    std-msgs \
+    geometry-msgs \
+"
+
+RDEPENDS_${PN} = " \
+    message-runtime \
+    std-msgs \
+    geometry-msgs \
+"
+
+require mavros.inc
+
+ROS_PKG_SUBDIR = "mavros_msgs"

--- a/recipes-ros/mavros/mavros.inc
+++ b/recipes-ros/mavros/mavros.inc
@@ -1,0 +1,8 @@
+SRC_URI = "https://github.com/mavlink/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "7d8fd22c44a9a5d384cd34c5a329d443"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "mavros"

--- a/recipes-ros/mavros/mavros_0.17.4.bb
+++ b/recipes-ros/mavros/mavros_0.17.4.bb
@@ -1,0 +1,49 @@
+DESCRIPTION = "MAVROS -- MAVLink extendable communication node for ROS with \
+proxy for Ground Control Station."
+LICENSE = "BSD | GPLv3 | LGPLv3"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=14;md5=9b511d4c606b1a23e454d3260818d003"
+
+# System dependencies
+
+DEPENDS = " \
+    boost \
+    libeigen \
+    ros-mavlink \
+"
+
+RDEPENDS_${PN} = " \
+    boost \
+    ros-mavlink \
+"
+
+# ROS packages dependencies
+MAVROS_RUN_AND_BUILD_DEPENDS = " \
+    diagnostic-updater \
+    eigen-conversions \
+    libmavconn \
+    pluginlib \
+    rosconsole-bridge \
+    roscpp \
+    tf2-ros \
+    diagnostic-msgs \
+    geometry-msgs \
+    mavros-msgs \
+    nav-msgs \
+    sensor-msgs \
+    std-msgs \
+    std-srvs \
+"
+
+DEPENDS_append = " \
+    angles \
+    cmake-modules \
+    message-runtime \
+    rospy \
+    ${MAVROS_RUN_AND_BUILD_DEPENDS} \
+"
+
+RDEPENDS_${PN}_append = "${MAVROS_RUN_AND_BUILD_DEPENDS}"
+
+require mavros.inc
+
+ROS_PKG_SUBDIR = "mavros"

--- a/recipes-ros/ros-mavlink/files/0001-Fix-PKG_NAME-_INCLUDE_DIR-variable.patch
+++ b/recipes-ros/ros-mavlink/files/0001-Fix-PKG_NAME-_INCLUDE_DIR-variable.patch
@@ -1,0 +1,31 @@
+From af522ba6b85be00a712618c719e831b941a8ffdc Mon Sep 17 00:00:00 2001
+From: Gustavo Jose de Sousa <gustavo.sousa@intel.com>
+Date: Wed, 16 Nov 2016 13:23:49 -0200
+Subject: [PATCH] Fix @PKG_NAME@_INCLUDE_DIR variable
+
+The previous approach hardcoded the path to the include directory and cross
+compilation using a sysroot directory would fail. This patch takes the
+resulting config files generated from other ROS packages as reference.
+
+Upstream-Status: Backport [https://github.com/mavlink/mavlink-gbp-release/pull/5]
+---
+ config.cmake.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/config.cmake.in b/config.cmake.in
+index b62ab64..34bed61 100644
+--- a/config.cmake.in
++++ b/config.cmake.in
+@@ -3,7 +3,8 @@ if (@PKG_NAME@_CONFIG_INCLUDED)
+ endif()
+ set(@PKG_NAME@_CONFIG_INCLUDED TRUE)
+ 
+-set(@PKG_NAME@_INCLUDE_DIRS "@CMAKE_INSTALL_PREFIX@/include")
++get_filename_component(include "${@PKG_NAME@_DIR}/../../../include" ABSOLUTE)
++set(@PKG_NAME@_INCLUDE_DIRS ${include})
+ set(@PKG_NAME@_DIALECTS @PKG_MAVLINK_DIALECTS@)
+ set(@PKG2_NAME@_DIALECTS @PKG2_MAVLINK_DIALECTS@)
+ 
+-- 
+2.10.2
+

--- a/recipes-ros/ros-mavlink/ros-mavlink_git.bb
+++ b/recipes-ros/ros-mavlink/ros-mavlink_git.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "MAVLink message marshaling library"
+LICENSE = "LGPLv3"
+LIC_FILES_CHKSUM = "file://COPYING;md5=54ad3cbe91bebcf6b1823970ff1fb97f"
+
+SRC_URI = "git://github.com/mavlink/mavlink-gbp-release.git;branch=release/${ROSDISTRO}/mavlink"
+SRCREV = "${AUTOREV}"
+
+SRC_URI += "file://0001-Fix-PKG_NAME-_INCLUDE_DIR-variable.patch"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "python-setuptools"
+
+inherit catkin


### PR DESCRIPTION
Hi all,

This pull request is very similar to the work done in https://github.com/bmwcarit/meta-ros/pull/424, but with the differences:

 - Download tarball instead of checking out a git repository.
 - The change in config.cmake.in uses what is done in the automatically generated files as reference for setting `mavlink_INCLUDE_DIRS` variable.
 - The mavlink files are in fact stored under `/opt/ros/indigo`, where it should be, based on the Ubuntu distribution. The last time I checked building with that #424, they were conflicting with another mavlink installation (one that goes to the standard locations).
 - The license checksum variables are set consistently with what has been done in other recipes in this repository.
 - Build and run dependencies set (although it seems that the current version of #424 apparently has fixed that).

@JochiPochi Your comments on this are very appreciated, since you've been working on this too for a while.

Best regards,
Gustavo Sousa