### PR TITLE
rosconsole: add include in console.h (resolves #433)

### DIFF
--- a/recipes-ros/ros-comm/rosconsole/0001-Add-Include-vector-to-fix-building-on-GCC-6.patch
+++ b/recipes-ros/ros-comm/rosconsole/0001-Add-Include-vector-to-fix-building-on-GCC-6.patch
@@ -1,0 +1,34 @@
+From 74674c49a64abbdcdd5aeea016997af2959c6f05 Mon Sep 17 00:00:00 2001
+From: Hodorgasm <nsane457@gmail.com>
+Date: Mon, 3 Oct 2016 20:32:20 -0400
+Subject: [PATCH] Add '#Include <vector>' to fix building on GCC-6
+
+Don't rely on transitive header inclusion to declare std::vector as building with GCC-6 fails due to no '#Include <vector>' statement.
+
+Upstream-Status: Backport [https://github.com/ros/ros_comm/commit/74674c49a64abbdcdd5aeea016997af2959c6f05]
+
+This patch has been generated with:
+  `git format-patch -1 74674c49a64abbdcdd5aeea016997af2959c6f05`
+in the kinetic branch of the ros_comm repository.
+This patch applies without modifications to the indigo release 1.11.20.
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
+---
+ tools/rosconsole/include/ros/console.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tools/rosconsole/include/ros/console.h b/tools/rosconsole/include/ros/console.h
+index 4d2a86b..28901d7 100644
+--- a/tools/rosconsole/include/ros/console.h
++++ b/tools/rosconsole/include/ros/console.h
+@@ -40,6 +40,7 @@
+ #include <cstdarg>
+ #include <ros/macros.h>
+ #include <map>
++#include <vector>
+ 
+ #ifdef ROSCONSOLE_BACKEND_LOG4CXX
+ #include "log4cxx/level.h"
+-- 
+2.5.5
+

--- a/recipes-ros/ros-comm/rosconsole_1.11.20.bb
+++ b/recipes-ros/ros-comm/rosconsole_1.11.20.bb
@@ -8,3 +8,5 @@ DEPENDS = "apr boost cpp-common log4cxx rostime rosunit"
 require ros-comm.inc
 
 ROS_PKG_SUBDIR = "tools"
+
+SRC_URI += "file://0001-Add-Include-vector-to-fix-building-on-GCC-6.patch;striplevel=3"


### PR DESCRIPTION
Compiling rosconsole failed with:
```
[...]/ros_comm-1.11.20/tools/rosconsole/include/ros/console.h:121:14: error: 'vector' in namespace 'std' does not name a template type
 typedef std::vector<TokenPtr> V_Token;
```

The console.h assumed that vector is included already by one of its dependencies. This bold assumption has been uncovered by the update of the boost library to version 1.62.0 [1, 2] in openembedded-core repository.

Coincidently, this issue was also noticed by ROS users on Gentoo and Arch Linux, which probably also use the latest boost library and gcc6, and they opened pull requests on the indigo and kinetic branches [3, 4, 5] with commits to address the issue. The patch in the kinetic branch has been merged, the others to the indigo branch have been rejected as the ros-comm maintainers intend to simply backport the patch from the kinetic branch for the next release.

This commit applies the patch merged in the kinetic branch in our recipe for the current indigo release version.

[1] http://cgit.openembedded.org/openembedded-core/commit/?id=c31030d87cd1741a4186d711325b8eab9c70b327
[2] http://cgit.openembedded.org/openembedded-core/commit/?id=42b4fa2f923244bc047874752d2e0381ff6f0a25
[3] https://github.com/ros/ros_comm/pull/911
[4] https://github.com/ros/ros_comm/pull/930
[5] https://github.com/ros/ros_comm/pull/939