### PR TITLE
sphinxbase: add build dependencies to sphinxbase

### DIFF
--- a/recipes-extended/cmusphinx/sphinxbase_0.8.bb
+++ b/recipes-extended/cmusphinx/sphinxbase_0.8.bb
@@ -12,6 +12,10 @@ require cmusphinx.inc
 
 SRC_URI += "file://0001-TESTS-srcdir-remove.patch"
 
+DEPENDS = "libsndfile1 alsa-lib libsamplerate0"
+
+EXTRA_OECONF = " --without-python"
+
 do_install_append () {
     #remove egg-info
     rm -rf ${D}/${PYTHON_SITEPACKAGES_DIR}/*.egg-info


### PR DESCRIPTION
sphinxbase is linked to libsndfile1, libasound from alsa-lib and
libsamplerate0, but these build dependencies are missing in the
recipe.

This update adds the missing dependencies.

Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>