### PR TITLE
Make meta-ros build against recent OpenEmbedded with recipe specific sysroots

### DIFF
--- a/recipes-devtools/python/python-rosdep/0001-Remove-build-dependency-on-nose-from-setup.py-491.patch
+++ b/recipes-devtools/python/python-rosdep/0001-Remove-build-dependency-on-nose-from-setup.py-491.patch
@@ -1,0 +1,37 @@
+From aae6b852e318015f46b2d49134594e14ca9d1321 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rojkov@gmail.com>
+Date: Wed, 21 Dec 2016 23:03:53 +0200
+Subject: [PATCH] Remove build dependency on nose from setup.py (#491)
+
+Having nose required to run setup.py is needed only to enable
+the `nosetests` command which is redundant since it duplicates
+the `test` command. Also it prevents building python-rosdep
+in build environments where external downloads during build time
+are prohibited in order to provide reproducible and more reliable
+builds.
+
+Upstream-Status: Accepted [https://github.com/ros-infrastructure/rosdep/pull/491]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ setup.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 0f6950c..a2146cf 100644
+--- a/setup.py
++++ b/setup.py
+@@ -9,9 +9,8 @@ setup(
+     packages=['rosdep2', 'rosdep2.platforms'],
+     package_dir={'': 'src'},
+     install_requires=['catkin_pkg', 'rospkg >= 1.0.37', 'rosdistro >= 0.4.0', 'PyYAML >= 3.1'],
+-    setup_requires=['nose >= 1.0'],
+     test_suite='nose.collector',
+-    test_requires=['mock'],
++    test_requires=['mock', 'nose >= 1.0'],
+     scripts=['scripts/rosdep', 'scripts/rosdep-source'],
+     author="Tully Foote, Ken Conley",
+     author_email="tfoote@osrfoundation.org",
+-- 
+2.7.4
+

--- a/recipes-devtools/python/python-rosdep_0.11.5.bb
+++ b/recipes-devtools/python/python-rosdep_0.11.5.bb
@@ -4,9 +4,9 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=8;endline=8;md5=e910b35b0ef4e1f665b9a75d6afb7709"
 SRCNAME = "rosdep"
 
-DEPENDS = "python-nose"
-
-SRC_URI = "http://download.ros.org/downloads/rosdep/rosdep-${PV}.tar.gz"
+SRC_URI = "http://download.ros.org/downloads/rosdep/rosdep-${PV}.tar.gz \
+           file://0001-Remove-build-dependency-on-nose-from-setup.py-491.patch \
+           "
 SRC_URI[md5sum] = "2c5669bc5cafcb1df8cd21ce14844cc4"
 SRC_URI[sha256sum] = "46e072074270a1ea25411829814f4bdc1f34b358c950e9b8a7b75b4a40efd96a"
 

--- a/recipes-extended/collada-dom/collada-dom/0001-Fix-return-value-to-be-of-expected-type.patch
+++ b/recipes-extended/collada-dom/collada-dom/0001-Fix-return-value-to-be-of-expected-type.patch
@@ -1,0 +1,31 @@
+From 83899b26ad9c0c565cd41ef296e758675dda003d Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Thu, 2 Feb 2017 10:37:52 +0200
+Subject: [PATCH] Fix return value to be of expected type
+
+The expected type is a pointer, but the code returns a boolean
+value. This makes compilation fail with recent gcc.
+
+Upstream-Status: Submitted [https://sourceforge.net/p/collada-dom/patches/10/]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ dom/src/dae/daeMetaGroup.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dom/src/dae/daeMetaGroup.cpp b/dom/src/dae/daeMetaGroup.cpp
+index 676141f..d51dd78 100644
+--- a/dom/src/dae/daeMetaGroup.cpp
++++ b/dom/src/dae/daeMetaGroup.cpp
+@@ -26,7 +26,7 @@ daeElement *daeMetaGroup::placeElement( daeElement *parent, daeElement *child, d
+ 	(void)offset;
+ 	daeString nm = child->getElementName();
+ 	if ( findChild( nm ) == NULL ) {
+-		return false;
++		return NULL;
+ 	}
+ 	daeElementRef el;
+ 
+-- 
+2.7.4
+

--- a/recipes-extended/collada-dom/collada-dom_2.4.0.bb
+++ b/recipes-extended/collada-dom/collada-dom_2.4.0.bb
@@ -6,7 +6,9 @@ LIC_FILES_CHKSUM = "file://License_Folder/license_e.txt;md5=33ea5b7341abf67bd905
 
 DEPENDS = "boost libxml2 libpcre"
 
-SRC_URI = "${SOURCEFORGE_MIRROR}/${BPN}/${BP}.tgz"
+SRC_URI = "${SOURCEFORGE_MIRROR}/${BPN}/${BP}.tgz \
+           file://0001-Fix-return-value-to-be-of-expected-type.patch \
+           "
 SRC_URI[md5sum] = "20399de4206eab850c32e65c04e907cb"
 SRC_URI[sha256sum] = "5ca2d12f744bdceff0066ed3067b3b23d6859581fb0d657f98ba4487d8fa3896"
 

--- a/recipes-ros/catkin/catkin.inc
+++ b/recipes-ros/catkin/catkin.inc
@@ -12,6 +12,7 @@ SRC_URI[sha256sum] = "81aff570966cb99d6305881cce6a645080a9778380e7fc2e67a33ac972
 SRC_URI += "\
     file://0001-CATKIN_WORKSPACES-Don-t-require-.catkin-file.patch \
     file://0001-use-python-provided-by-environment-instead-of-the-ge.patch \
+    file://0001-avoid-using-host-s-paths-when-cross-compiling.patch \
     "
 
 inherit catkin

--- a/recipes-ros/catkin/catkin.inc
+++ b/recipes-ros/catkin/catkin.inc
@@ -13,6 +13,7 @@ SRC_URI += "\
     file://0001-CATKIN_WORKSPACES-Don-t-require-.catkin-file.patch \
     file://0001-use-python-provided-by-environment-instead-of-the-ge.patch \
     file://0001-avoid-using-host-s-paths-when-cross-compiling.patch \
+    file://0001-relocate-dependency-s-headers-to-current-sysroot.patch \
     "
 
 inherit catkin

--- a/recipes-ros/catkin/files/0001-avoid-using-host-s-paths-when-cross-compiling.patch
+++ b/recipes-ros/catkin/files/0001-avoid-using-host-s-paths-when-cross-compiling.patch
@@ -1,0 +1,76 @@
+From 1aa4eeea5b693e67f41e59cf1b0019f45d3a8976 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Mon, 6 Feb 2017 16:15:16 +0200
+Subject: [PATCH 1/2] avoid using host's paths when cross-compiling
+
+This patch makes catkin to look for libraries only under Yocto's
+sysroots and if a library is found the actual directory is used
+for that library. Not the one that was provided to CMake's
+find_library() command.
+
+For better insights please refer to this WONTFIX'ed issue
+https://github.com/ros/catkin/issues/379
+
+Upstream-Status: Inappropriate [suitable for Yocto only]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+
+---
+ cmake/catkin_package.cmake         | 10 ++++++++--
+ cmake/templates/pkgConfig.cmake.in |  4 ++--
+ 2 files changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/cmake/catkin_package.cmake b/cmake/catkin_package.cmake
+index 7d56edf..71f700f 100644
+--- a/cmake/catkin_package.cmake
++++ b/cmake/catkin_package.cmake
+@@ -104,6 +104,9 @@ function(_catkin_package)
+     message(FATAL_ERROR "catkin_package() called with unused arguments: ${PROJECT_UNPARSED_ARGUMENTS}")
+   endif()
+ 
++  # cmake.bbclass always sets $STAGING_DIR as the first value of CMAKE_FIND_ROOT_PATH
++  list(GET CMAKE_FIND_ROOT_PATH 0 ROOT_PATH)
++
+   if(NOT ${PROJECT_NAME} STREQUAL "catkin")
+     list(FIND ${PROJECT_NAME}_BUILDTOOL_DEPENDS "catkin" _index)
+     if(_index EQUAL -1)
+@@ -231,7 +234,8 @@ function(_catkin_package)
+   # get library paths from all workspaces
+   set(lib_paths "")
+   foreach(workspace ${CATKIN_WORKSPACES})
+-    list_append_unique(lib_paths ${workspace}/lib)
++    string(REPLACE ${ROOT_PATH} "" tweaked_ws ${workspace})
++    list_append_unique(lib_paths ${tweaked_ws}/lib)
+   endforeach()
+ 
+   # merge explicitly listed libraries and libraries from non-catkin but find_package()-ed packages
+@@ -250,7 +254,9 @@ function(_catkin_package)
+   catkin_pack_libraries_with_build_configuration(_PKG_CONFIG_LIBRARIES ${_PKG_CONFIG_LIBRARIES})
+   set(PKG_CONFIG_LIBRARIES "")
+   foreach(library ${_PKG_CONFIG_LIBRARIES})
+-    list_append_deduplicate(PKG_CONFIG_LIBRARIES ${library})
++    string(REPLACE ${ROOT_PATH} "" newlib ${library})
++    get_filename_component(newlib ${newlib} NAME)
++    list_append_deduplicate(PKG_CONFIG_LIBRARIES ${newlib})
+   endforeach()
+   catkin_unpack_libraries_with_build_configuration(PKG_CONFIG_LIBRARIES ${PKG_CONFIG_LIBRARIES})
+ 
+diff --git a/cmake/templates/pkgConfig.cmake.in b/cmake/templates/pkgConfig.cmake.in
+index d99b811..c692108 100644
+--- a/cmake/templates/pkgConfig.cmake.in
++++ b/cmake/templates/pkgConfig.cmake.in
+@@ -125,9 +125,9 @@ foreach(library ${libraries})
+     foreach(path @PKG_CONFIG_LIB_PATHS@)
+       find_library(lib ${library}
+         PATHS ${path}
+-        NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
++        NO_DEFAULT_PATH ONLY_CMAKE_FIND_ROOT_PATH)
+       if(lib)
+-        set(lib_path ${path})
++        get_filename_component(lib_path ${lib} DIRECTORY)
+         break()
+       endif()
+     endforeach()
+-- 
+2.7.4
+

--- a/recipes-ros/catkin/files/0001-relocate-dependency-s-headers-to-current-sysroot.patch
+++ b/recipes-ros/catkin/files/0001-relocate-dependency-s-headers-to-current-sysroot.patch
@@ -1,0 +1,80 @@
+From b0ad0d6e6a7872c59180596d29ac5f52723c4317 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Wed, 22 Feb 2017 13:48:37 +0200
+Subject: [PATCH] relocate dependency's headers to current sysroot
+
+If a package (A) depends on another package (B) and the package
+B depends on Boost then it might happen that B produces BConfig.cmake
+file where absolute paths to Boost's headers are put (because CMake's
+standard FindBoost.cmake module reports absolute paths). In case of
+Yocto it means that BConfig.cmake will contain something like
+/path/to/build/tmp-glibc/work/i586/package_B/0.0.1/recipe-sysroot/usr/include.
+The path may not exist at the moment when the package A is being built.
+And that leads to the failure of the check this patch switches off.
+
+The problem has been reported to catkin's issue tracker:
+https://github.com/ros/catkin/issues/851
+
+This patch "relocates" required headers from dependencies' sysroots
+to the current sysroot by removing sysroot prefix from include dirs
+in *Config.cmake files at the moment the files get created and
+by prepending the include dirs again with the current sysroot prefix.
+
+Upstream-Status: Inappropriate [suitable for Yocto's RSS feature only]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+
+---
+ cmake/catkin_package.cmake         |  5 ++++-
+ cmake/templates/pkgConfig.cmake.in | 10 +++++++---
+ 2 files changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/cmake/catkin_package.cmake b/cmake/catkin_package.cmake
+index 71f700f..818ccd9 100644
+--- a/cmake/catkin_package.cmake
++++ b/cmake/catkin_package.cmake
+@@ -161,7 +161,10 @@ function(_catkin_package)
+           if(NOT ${${depend_name}_FOUND})
+             message(FATAL_ERROR "catkin_package() DEPENDS on '${depend_name}' which must be find_package()-ed before. If it is a catkin package it can be declared as CATKIN_DEPENDS instead without find_package()-ing it.")
+           endif()
+-          list(APPEND PROJECT_DEPENDENCIES_INCLUDE_DIRS ${${depend_name}_INCLUDE_DIRS})
++          foreach(incdir ${${depend_name}_INCLUDE_DIRS})
++            string(REPLACE ${ROOT_PATH} "" tweaked_idir ${incdir})
++            list_append_deduplicate(PROJECT_DEPENDENCIES_INCLUDE_DIRS ${tweaked_idir})
++          endforeach()
+           list(APPEND PROJECT_DEPENDENCIES_LIBRARIES ${${depend_name}_LIBRARIES})
+         endif()
+       endforeach()
+diff --git a/cmake/templates/pkgConfig.cmake.in b/cmake/templates/pkgConfig.cmake.in
+index c692108..683ef67 100644
+--- a/cmake/templates/pkgConfig.cmake.in
++++ b/cmake/templates/pkgConfig.cmake.in
+@@ -94,18 +94,22 @@ set(@PROJECT_NAME@_FOUND_CATKIN_PROJECT TRUE)
+ if(NOT "@PROJECT_CMAKE_CONFIG_INCLUDE_DIRS@ " STREQUAL " ")
+   set(@PROJECT_NAME@_INCLUDE_DIRS "")
+   set(_include_dirs "@PROJECT_CMAKE_CONFIG_INCLUDE_DIRS@")
++  list(GET CMAKE_FIND_ROOT_PATH 0 root_path)
+   foreach(idir ${_include_dirs})
++    if(IS_ABSOLUTE ${idir} AND NOT "${idir}" MATCHES "^${root_path}.*")
++      set(idir "${root_path}${idir}")
++    endif()
+     if(IS_ABSOLUTE ${idir} AND IS_DIRECTORY ${idir})
+-      set(include ${idir})
++      _list_append_unique(@PROJECT_NAME@_INCLUDE_DIRS ${idir})
+     elseif("${idir} " STREQUAL "@CATKIN_GLOBAL_INCLUDE_DESTINATION@ ")
+       get_filename_component(include "${@PROJECT_NAME@_DIR}/../../../@CATKIN_GLOBAL_INCLUDE_DESTINATION@" ABSOLUTE)
+       if(NOT IS_DIRECTORY ${include})
+         message(FATAL_ERROR "Project '@PROJECT_NAME@' specifies '${idir}' as an include dir, which is not found.  It does not exist in '${include}'.  Ask the maintainer '@PROJECT_MAINTAINER@' to fix it.")
+       endif()
++      _list_append_unique(@PROJECT_NAME@_INCLUDE_DIRS ${include})
+     else()
+-      message(FATAL_ERROR "Project '@PROJECT_NAME@' specifies '${idir}' as an include dir, which is not found.  It does neither exist as an absolute directory nor in '@PKG_INCLUDE_PREFIX@/${idir}'.  Ask the maintainer '@PROJECT_MAINTAINER@' to fix it.")
++      message(WARNING "Project '@PROJECT_NAME@' specifies '${idir}' as an include dir, which is not found.  It does neither exist as an absolute directory nor in '@PKG_INCLUDE_PREFIX@/${idir}'.  Ask the maintainer '@PROJECT_MAINTAINER@' to fix it.")
+     endif()
+-    _list_append_unique(@PROJECT_NAME@_INCLUDE_DIRS ${include})
+   endforeach()
+ endif()
+ 
+-- 
+2.7.4
+

--- a/recipes-ros/control-toolbox/control-toolbox_1.13.2.bb
+++ b/recipes-ros/control-toolbox/control-toolbox_1.13.2.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 DEPENDS = "rosconsole tf roscpp angles message-generation dynamic-reconfigure libtinyxml \
-    realtime-tools message-filters"
+    realtime-tools message-filters python-rospkg"
 
 SRC_URI = "https://github.com/ros-controls/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "40bc1f04e5936b7fee824f6717702a62"

--- a/recipes-ros/depthimage-to-laserscan/depthimage-to-laserscan/0001-Add-missing-std-namespace-prefixes.patch
+++ b/recipes-ros/depthimage-to-laserscan/depthimage-to-laserscan/0001-Add-missing-std-namespace-prefixes.patch
@@ -1,0 +1,58 @@
+From 736d9a4598018d174bb33580c920c295df317825 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Mon, 6 Feb 2017 15:55:09 +0200
+Subject: [PATCH] Add missing std namespace prefixes
+
+Upstream-Status: Submitted [https://github.com/ros-perception/depthimage_to_laserscan/pull/20]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ src/DepthImageToLaserScan.cpp      | 2 +-
+ test/DepthImageToLaserScanTest.cpp | 6 +++---
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/DepthImageToLaserScan.cpp b/src/DepthImageToLaserScan.cpp
+index 6ad0487..f1949ba 100644
+--- a/src/DepthImageToLaserScan.cpp
++++ b/src/DepthImageToLaserScan.cpp
+@@ -59,7 +59,7 @@ bool DepthImageToLaserScan::use_point(const float new_value, const float old_val
+   
+   // Infs are preferable over NaNs (more information)
+   if(!new_finite && !old_finite){ // Both are not NaN or Inf.
+-    if(!isnan(new_value)){ // new is not NaN, so use it's +-Inf value.
++    if(!std::isnan(new_value)){ // new is not NaN, so use it's +-Inf value.
+       return true;
+     }
+     return false; // Do not replace old_value
+diff --git a/test/DepthImageToLaserScanTest.cpp b/test/DepthImageToLaserScanTest.cpp
+index 1b4acc2..dbf25e3 100644
+--- a/test/DepthImageToLaserScanTest.cpp
++++ b/test/DepthImageToLaserScanTest.cpp
+@@ -235,7 +235,7 @@ TEST(ConvertTest, testPositiveInf)
+   for(size_t i = 0; i < scan_msg->ranges.size(); i++){
+     if(std::isfinite(scan_msg->ranges[i])){ // NaNs are acceptable.
+       ADD_FAILURE() << "Non-finite value produced from postive infniity test.";
+-    } else if(isnan(scan_msg->ranges[i])){
++    } else if(std::isnan(scan_msg->ranges[i])){
+       nan_count++;
+     } else if(scan_msg->ranges[i] < 0){
+       ADD_FAILURE() << "Negative value produced from postive infinity test.";
+@@ -267,7 +267,7 @@ TEST(ConvertTest, testNegativeInf)
+   for(size_t i = 0; i < scan_msg->ranges.size(); i++){
+     if(std::isfinite(scan_msg->ranges[i])){ // NaNs are acceptable.
+       ADD_FAILURE() << "Non-finite value produced from postive infniity test.";
+-    } else if(isnan(scan_msg->ranges[i])){
++    } else if(std::isnan(scan_msg->ranges[i])){
+       nan_count++;
+     } else if(scan_msg->ranges[i] > 0){
+       ADD_FAILURE() << "Postive value produced from negative infinity test.";
+@@ -282,4 +282,4 @@ TEST(ConvertTest, testNegativeInf)
+ int main(int argc, char **argv){
+ testing::InitGoogleTest(&argc, argv);
+ return RUN_ALL_TESTS();
+-}
+\ No newline at end of file
++}
+-- 
+2.7.4
+

--- a/recipes-ros/depthimage-to-laserscan/depthimage-to-laserscan_1.0.7.bb
+++ b/recipes-ros/depthimage-to-laserscan/depthimage-to-laserscan_1.0.7.bb
@@ -5,7 +5,9 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=d566ef916e9dedc
 
 DEPENDS = "roscpp sensor-msgs nodelet image-transport image-geometry dynamic-reconfigure python-rospkg"
 
-SRC_URI = "https://github.com/ros-perception/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI = "https://github.com/ros-perception/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz \
+           file://0001-Add-missing-std-namespace-prefixes.patch \
+           "
 SRC_URI[md5sum] = "b8fb5b855be4f7a8d22377d5d866bb47"
 SRC_URI[sha256sum] = "3aa236f81cfd26e55718edfb50ef837a59b57169cb20a5b24f9a4e99602a09e8"
 

--- a/recipes-ros/depthimage-to-laserscan/depthimage-to-laserscan_1.0.7.bb
+++ b/recipes-ros/depthimage-to-laserscan/depthimage-to-laserscan_1.0.7.bb
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "roscpp sensor-msgs nodelet image-transport image-geometry dynamic-reconfigure"
+DEPENDS = "roscpp sensor-msgs nodelet image-transport image-geometry dynamic-reconfigure python-rospkg"
 
 SRC_URI = "https://github.com/ros-perception/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "b8fb5b855be4f7a8d22377d5d866bb47"

--- a/recipes-ros/geometry/tf-conversions_1.11.8.bb
+++ b/recipes-ros/geometry/tf-conversions_1.11.8.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=19;endline=19;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "libeigen geometry-msgs kdl-conversions tf"
+DEPENDS = "libeigen geometry-msgs kdl-conversions tf cmake-modules"
 
 require geometry.inc

--- a/recipes-ros/geometry2/tf2-kdl_0.5.13.bb
+++ b/recipes-ros/geometry2/tf2-kdl_0.5.13.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "libeigen orocos-kdl tf2 tf2-ros"
+DEPENDS = "libeigen orocos-kdl tf2 tf2-ros cmake-modules"
 
 require geometry2.inc

--- a/recipes-ros/image-common/image-transport_1.11.11.bb
+++ b/recipes-ros/image-common/image-transport_1.11.11.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "message-filters pluginlib rosconsole roscpp roslib sensor-msgs"
+DEPENDS = "message-filters pluginlib rosconsole roscpp roslib sensor-msgs class-loader"
 
 require image-common.inc

--- a/recipes-ros/image-pipeline/image-proc_1.12.19.bb
+++ b/recipes-ros/image-pipeline/image-proc_1.12.19.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "boost camera-calibration-parsers cv-bridge dynamic-reconfigure image-geometry image-transport nodelet opencv roscpp sensor-msgs"
+DEPENDS = "boost camera-calibration-parsers cv-bridge dynamic-reconfigure image-geometry image-transport nodelet opencv roscpp sensor-msgs python-rospkg"
 
 require image-pipeline.inc

--- a/recipes-ros/image-pipeline/image-publisher_1.12.19.bb
+++ b/recipes-ros/image-pipeline/image-publisher_1.12.19.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "camera-info-manager cv-bridge dynamic-reconfigure image-transport nodelet roscpp sensor-msgs"
+DEPENDS = "camera-info-manager cv-bridge dynamic-reconfigure image-transport nodelet roscpp sensor-msgs python-rospkg"
 
 require image-pipeline.inc

--- a/recipes-ros/image-pipeline/image-rotate_1.12.19.bb
+++ b/recipes-ros/image-pipeline/image-rotate_1.12.19.bb
@@ -4,6 +4,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=26;endline=26;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cmake-modules cv-bridge dynamic-reconfigure eigen-conversions image-transport nodelet opencv roscpp tf2 tf2-geometry-msgs tf2-ros"
+DEPENDS = "cmake-modules cv-bridge dynamic-reconfigure eigen-conversions image-transport nodelet opencv roscpp tf2 tf2-geometry-msgs tf2-ros python-rospkg"
 
 require image-pipeline.inc

--- a/recipes-ros/image-transport-plugins/compressed-depth-image-transport_1.9.5.bb
+++ b/recipes-ros/image-transport-plugins/compressed-depth-image-transport_1.9.5.bb
@@ -4,6 +4,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf"
+DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf python-rospkg"
 
 require image-transport-plugins.inc

--- a/recipes-ros/image-transport-plugins/compressed-image-transport_1.9.5.bb
+++ b/recipes-ros/image-transport-plugins/compressed-image-transport_1.9.5.bb
@@ -4,6 +4,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf"
+DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf python-rospkg"
 
 require image-transport-plugins.inc

--- a/recipes-ros/image-transport-plugins/theora-image-transport_1.9.5.bb
+++ b/recipes-ros/image-transport-plugins/theora-image-transport_1.9.5.bb
@@ -4,6 +4,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf rosbag"
+DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf rosbag python-rospkg"
 
 require image-transport-plugins.inc

--- a/recipes-ros/laser-filters/laser-filters/0001-Use-std-namespace-for-c-11-compat.patch
+++ b/recipes-ros/laser-filters/laser-filters/0001-Use-std-namespace-for-c-11-compat.patch
@@ -1,0 +1,45 @@
+From 9631aaabd65e10615baebd30273b57677ba4d49c Mon Sep 17 00:00:00 2001
+From: Mike Purvis <mpurvis@clearpathrobotics.com>
+Date: Fri, 15 Jul 2016 23:47:45 -0400
+Subject: [PATCH] Use std:: namespace for c++11 compat.
+
+Upstream-Status: Backported
+
+---
+ include/laser_filters/intensity_filter.h | 4 ++--
+ test/test_scan_filter_chain.cpp          | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/include/laser_filters/intensity_filter.h b/include/laser_filters/intensity_filter.h
+index 3f175a0..4c9cfbc 100644
+--- a/include/laser_filters/intensity_filter.h
++++ b/include/laser_filters/intensity_filter.h
+@@ -99,8 +99,8 @@ public:
+       // Calculate histogram
+       if (disp_hist_enabled_){
+         // If intensity value is inf or NaN, skip voting histogram
+-        if( isinf((double)filtered_scan.intensities[i]) ||
+-            isnan((double)filtered_scan.intensities[i]) )
++        if( std::isinf((double)filtered_scan.intensities[i]) ||
++            std::isnan((double)filtered_scan.intensities[i]) )
+           continue;
+ 
+         // Choose bucket to vote on histogram,
+diff --git a/test/test_scan_filter_chain.cpp b/test/test_scan_filter_chain.cpp
+index b661f5f..139da60 100644
+--- a/test/test_scan_filter_chain.cpp
++++ b/test/test_scan_filter_chain.cpp
+@@ -60,8 +60,8 @@ sensor_msgs::LaserScan gen_msg(){
+  */
+ void expect_ranges_eq(const std::vector<float> &a, const std::vector<float> &b) {
+   for( int i=0; i<10; i++) {
+-    if(isnan(a[i])) {
+-      EXPECT_TRUE(isnan(a[i]));
++    if(std::isnan(a[i])) {
++      EXPECT_TRUE(std::isnan(a[i]));
+     }
+     else {
+       EXPECT_NEAR(a[i], b[i], 1e-6);
+-- 
+2.7.4
+

--- a/recipes-ros/laser-filters/laser-filters_1.8.3.bb
+++ b/recipes-ros/laser-filters/laser-filters_1.8.3.bb
@@ -6,7 +6,9 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9de
 
 DEPENDS = "angles filters laser-geometry message-filters pluginlib roscpp sensor-msgs tf"
 
-SRC_URI = "https://github.com/ros-perception/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI = "https://github.com/ros-perception/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz \
+           file://0001-Use-std-namespace-for-c-11-compat.patch \
+           "
 SRC_URI[md5sum] = "566b4a51d0d11522d7528ca437c42b0f"
 SRC_URI[sha256sum] = "3e124b474c0c0da419366fa21a101874cc7e4c83b352a2da5a21e1967c68555f"
 

--- a/recipes-ros/laser-geometry/laser-geometry_1.6.4.bb
+++ b/recipes-ros/laser-geometry/laser-geometry_1.6.4.bb
@@ -5,7 +5,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "angles boost libeigen sensor-msgs roscpp tf"
+DEPENDS = "angles boost libeigen sensor-msgs roscpp tf cmake-modules"
 
 SRC_URI = "https://github.com/ros-perception/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "1ee7479b8c5914b4ffae996945121441"

--- a/recipes-ros/navigation/amcl_1.12.13.bb
+++ b/recipes-ros/navigation/amcl_1.12.13.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=21;endline=21;md5=58d727014cda5ed405b7fb52666a1f97"
 
-DEPENDS = "dynamic-reconfigure message-filters nav-msgs rosbag roscpp std-srvs tf"
+DEPENDS = "dynamic-reconfigure message-filters nav-msgs rosbag roscpp std-srvs tf python-rospkg"
 
 require navigation.inc

--- a/recipes-ros/navigation/base-local-planner_1.12.13.bb
+++ b/recipes-ros/navigation/base-local-planner_1.12.13.bb
@@ -6,6 +6,6 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=01c2bc31767cc
 
 DEPENDS = "angles costmap-2d dynamic-reconfigure geometry-msgs libeigen message-generation \
     nav-core nav-msgs pcl-conversions pcl-ros pluginlib rosconsole roscpp rospy std-msgs tf \
-    voxel-grid visualization-msgs"
+    voxel-grid visualization-msgs rostest"
 
 require navigation.inc

--- a/recipes-ros/nodelet-core/nodelet-topic-tools_1.9.8.bb
+++ b/recipes-ros/nodelet-core/nodelet-topic-tools_1.9.8.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "dynamic-reconfigure"
+DEPENDS = "dynamic-reconfigure python-rospkg"
 
 require nodelet-core.inc

--- a/recipes-ros/razor-imu-9dof/razor-imu-9dof_1.1.1.bb
+++ b/recipes-ros/razor-imu-9dof/razor-imu-9dof_1.1.1.bb
@@ -7,7 +7,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=15;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "dynamic-reconfigure"
+DEPENDS = "dynamic-reconfigure python-rospkg"
 
 SRC_URI = "https://github.com/KristofRobot/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "4712cbe1d9d8bacd9eebfd51825ada36"

--- a/recipes-ros/robot-model/collada-urdf_1.11.11.bb
+++ b/recipes-ros/robot-model/collada-urdf_1.11.11.bb
@@ -7,12 +7,3 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=16;endline=16;md5=d566ef916e9de
 DEPENDS = "angles assimp resource-retriever collada-dom collada-parser roscpp urdf geometric-shapes tf"
 
 require robot-model.inc
-
-do_configure_append() {
-    for f in collada_urdf.dir collada_to_urdf.dir urdf_to_collada.dir
-    do
-    sed -i -e 's: /usr/lib/liboctomap.so: ${STAGING_LIBDIR}/liboctomap.so:g' \
-        -e 's: /usr/lib/liboctomath.so: ${STAGING_LIBDIR}/liboctomath.so:g' \
-        ${B}/CMakeFiles/$f/build.make
-    done
-}

--- a/recipes-ros/robot-model/collada-urdf_1.11.11.bb
+++ b/recipes-ros/robot-model/collada-urdf_1.11.11.bb
@@ -4,6 +4,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=16;endline=16;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "angles assimp resource-retriever collada-dom collada-parser roscpp urdf geometric-shapes tf"
+DEPENDS = "angles assimp resource-retriever collada-dom collada-parser roscpp urdf geometric-shapes tf libtinyxml"
 
 require robot-model.inc

--- a/recipes-ros/robot-model/kdl-parser/0001-add-explicit-dependency-on-libeigen.patch
+++ b/recipes-ros/robot-model/kdl-parser/0001-add-explicit-dependency-on-libeigen.patch
@@ -1,0 +1,45 @@
+From 48eebb8144f326040c82ea37e8cf00291fbc1403 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Fri, 17 Feb 2017 10:49:30 +0200
+Subject: [PATCH] add explicit dependency on libeigen
+
+libeigen is an interface dependency needed by orocos-kdl and
+orocos-kdl does export this dependency, but it does so with
+a hardcoded absolute path pointing to the sysroot where
+orocos-kdl was built. In case the sysroot doesn't exist
+the compiler can't find libeigen's headers.
+
+Unfortunately orocos-kdl's CMakeList.txt doesn't use
+per-target include dirs, but global ones. I don't know
+an easy way how to make them relocatable.
+
+The easiest way to fix it is to add the explicit dependency
+on libeigen to kdl-parser's CMakeList.txt. Anyway it's already
+been declarated as a dependency in kdl-parser's recipe.
+
+Upstream-Status: Inappropriate [It's not kdl-parser's problem, but orocos-kdl's one]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 43b96b7..5c96e55 100644
+--- aCMakeLists.txt
++++ bCMakeLists.txt
+@@ -9,9 +9,10 @@ find_package(catkin REQUIRED
+   COMPONENTS roscpp rosconsole urdf cmake_modules
+ )
+ find_package(orocos_kdl REQUIRED)
++find_package(Eigen3 REQUIRED)
+ find_package(TinyXML REQUIRED)
+ 
+-include_directories(include ${orocos_kdl_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
++include_directories(include ${EIGEN3_INCLUDE_DIR} ${orocos_kdl_INCLUDE_DIRS} ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+ 
+ link_directories(${catkin_LIBRARY_DIRS})
+ link_directories(${orocos_kdl_LIBRARY_DIRS})
+-- 
+2.7.4
+

--- a/recipes-ros/robot-model/kdl-parser_1.11.11.bb
+++ b/recipes-ros/robot-model/kdl-parser_1.11.11.bb
@@ -6,3 +6,7 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=15;md5=d566ef916e9de
 DEPENDS = "libeigen orocos-kdl rosconsole roscpp urdf cmake-modules"
 
 require robot-model.inc
+
+SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz \
+           file://0001-add-explicit-dependency-on-libeigen.patch \
+           "

--- a/recipes-ros/robot-model/urdf_1.11.11.bb
+++ b/recipes-ros/robot-model/urdf_1.11.11.bb
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=15;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "rosconsole-bridge roscpp urdfdom-headers urdf-parser-plugin pluginlib urdfdom cmake-modules libtinyxml"
+DEPENDS = "rosconsole-bridge roscpp urdfdom-headers urdf-parser-plugin pluginlib urdfdom cmake-modules libtinyxml class-loader"
 
 require robot-model.inc
 

--- a/recipes-ros/robot-state-publisher/robot-state-publisher_1.11.2.bb
+++ b/recipes-ros/robot-state-publisher/robot-state-publisher_1.11.2.bb
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=18;endline=18;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cmake-modules libeigen kdl-parser orocos-kdl rosconsole roscpp rostime sensor-msgs tf tf2-ros tf2-kdl"
+DEPENDS = "cmake-modules libeigen kdl-parser orocos-kdl rosconsole roscpp rostime sensor-msgs tf tf2-ros tf2-kdl rostest"
 
 SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "f10d326400fd97f349a19a330c65aa3a"


### PR DESCRIPTION
The PR includes fixes for
* stricter gcc checks,
* missing dependencies
* issues inflicted by the new RSS feature.

The main issue reported in https://github.com/ros/catkin/issues/851 hasn't been properly solved though, but worked around.