### PR TITLE
Fix the python3 conflict issues

### DIFF
--- a/recipes-ros/geometry/tf_1.11.8.bb
+++ b/recipes-ros/geometry/tf_1.11.8.bb
@@ -9,4 +9,4 @@ require geometry.inc
 
 SRC_URI += "file://0001-Fix-stdlib.h-No-such-file-or-directory-errors-in-GCC.patch;striplevel=2"
 
-RDEPENDS_${PN} = "python-numpy"
+RDEPENDS_${PN} = "python3-numpy"

--- a/recipes-ros/ros-comm/rostest_1.11.20.bb
+++ b/recipes-ros/ros-comm/rostest_1.11.20.bb
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "boost python-nose"
+DEPENDS = "boost python3-nose"
 DEPENDS_class-native = "boost-native rosunit-native"
 
 require ros-comm.inc


### PR DESCRIPTION
Since the latest opencv package depends on python3, we need to switch to python3 in meta-ros,
to fix the below bitbake error message in issue #458: “that file is already provided by package”

Signed-off-by: Yong Li <sdliyong@gmail.com>