### PR TITLE
moveit: Add packages from MoveIt! project

### DIFF
--- a/classes/ros-insane.bbclass
+++ b/classes/ros-insane.bbclass
@@ -1,0 +1,9 @@
+# Usually ROS packages include libraries without so-names. But some packages insist
+# on setting so-names to indicate ABI breakages between different versions of the
+# same library in the same ROS distro. E.g. see
+# https://github.com/ros-planning/moveit/commit/0a7a895bb2ae9e171efa101f354826366fa5eaff
+INSANE_SKIP_${PN} += "dev-so"
+
+FILES_${PN} += "\
+        ${ros_libdir}/lib*.so.* \
+"

--- a/recipes-extended/fcl/fcl/0001-Add-configure-option-NO_DEFAULT_RPATH.patch
+++ b/recipes-extended/fcl/fcl/0001-Add-configure-option-NO_DEFAULT_RPATH.patch
@@ -1,0 +1,54 @@
+From 627968a012ab9518fcbc26da52f0f395c583b772 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Tue, 7 Feb 2017 10:04:55 +0200
+Subject: [PATCH] Add configure option NO_DEFAULT_RPATH
+
+The currently used compiler settings explicitly set RPATH to
+installed binaries which is not desired behaviour in some
+circumstances, e.g. OpenEmbedded's QA checks report an issue
+about redundant RPATH set to the standard '/usr/lib' directory.
+
+This patch adds the configure option NO_DEFAULT_RPATH which is
+ON by default in order to preserve the current behaviour, but
+when set to OFF make CMake use its default RPATH settings, that is
+set RPATH for the binaries in the build tree, but clear them out
+for installed binaries.
+
+Upstream-Status: Accepted [https://github.com/flexible-collision-library/fcl/pull/203]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ CMakeModules/CompilerSettings.cmake | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeModules/CompilerSettings.cmake b/CMakeModules/CompilerSettings.cmake
+index c1c4ae5..3d9f805 100644
+--- a/CMakeModules/CompilerSettings.cmake
++++ b/CMakeModules/CompilerSettings.cmake
+@@ -40,11 +40,19 @@ if((CMAKE_COMPILER_IS_GNUCXX OR IS_ICPC) AND NOT MINGW)
+     add_definitions(-fPIC)
+ endif((CMAKE_COMPILER_IS_GNUCXX OR IS_ICPC) AND NOT MINGW)
+ 
++# By default CMake sets RPATH for binaries in the build tree, but clears
++# it when installing. Switch this option off if the default behaviour is
++# desired.
++option(NO_DEFAULT_RPATH "Set RPATH for installed binaries" ON)
++
+ # Set rpath http://www.paraview.org/Wiki/CMake_RPATH_handling
+-set(CMAKE_SKIP_BUILD_RPATH FALSE)
+-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
++if(NO_DEFAULT_RPATH)
++    message(STATUS "Set RPATH explicitly to '${CMAKE_INSTALL_PREFIX}/lib'")
++    set(CMAKE_SKIP_BUILD_RPATH FALSE)
++    set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
++    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
++    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
++endif(NO_DEFAULT_RPATH)
+ 
+ # no prefix needed for python modules
+ set(CMAKE_SHARED_MODULE_PREFIX "")
+-- 
+2.7.4
+

--- a/recipes-extended/fcl/fcl_0.3.2.bb
+++ b/recipes-extended/fcl/fcl_0.3.2.bb
@@ -6,7 +6,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=5823baab4b8de52197d0fb775e8fd4b7"
 # Octomap dependency not included as it is optional.
 DEPENDS = "boost libccd"
 
-SRC_URI = "https://github.com/flexible-collision-library/fcl/archive/${PV}.tar.gz"
+SRC_URI = "https://github.com/flexible-collision-library/fcl/archive/${PV}.tar.gz \
+           file://0001-Add-configure-option-NO_DEFAULT_RPATH.patch \
+          "
 SRC_URI[md5sum] = "b12246df3f4e1d0768ce1e46a52900ff"
 SRC_URI[sha256sum] = "cf914f85b32cf8b63879907726df64e50da33f00d538759d789fe10fc5fbc95b"
 
@@ -16,7 +18,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://LICENSE;subdir=fcl-${PV}"
 
-EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release"
+EXTRA_OECMAKE += "-DCMAKE_BUILD_TYPE=Release -DNO_DEFAULT_RPATH=OFF"
 FILES_${PN} += "${libdir}/libfcl.so"
 
 # Need to override this, otherwise libfcl.so is included in dev packageW.

--- a/recipes-ros/moveit-msgs/moveit-msgs_0.7.5.bb
+++ b/recipes-ros/moveit-msgs/moveit-msgs_0.7.5.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Messages, services and actions used by MoveIt"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "message-generation std-msgs trajectory-msgs geometry-msgs sensor-msgs actionlib-msgs octomap-msgs object-recognition-msgs"
+
+SRC_URI = "https://github.com/ros-planning/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "60f559b7501006c2e021271ceef771b0"
+SRC_URI[sha256sum] = "170b74b99c54fcf0334df2c4b0ecef84007d3bc0be7f9c530e69edf391320b4c"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin
+
+ROS_SPN = "moveit_msgs"

--- a/recipes-ros/moveit/moveit-0.7.8.inc
+++ b/recipes-ros/moveit/moveit-0.7.8.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/ros-planning/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "fadd453134bb64559b989d2b3f02ca28"
+SRC_URI[sha256sum] = "d14103ddf4545f42acaabfcdda36eeff9a293e07269d339eeb7ac4ab6dd3c522"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin ros-insane
+
+ROS_SPN = "moveit"

--- a/recipes-ros/moveit/moveit-core_0.7.8.bb
+++ b/recipes-ros/moveit/moveit-core_0.7.8.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Core libraries used by MoveIt!"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roslib boost eigen-conversions fcl octomap eigen-stl-containers geometric-shapes kdl-parser moveit-msgs srdfdom cmake-modules"
+
+require moveit-${PV}.inc

--- a/recipes-ros/moveit/moveit-ros-perception/0001-moveit_ros_perception-make-OpenGL-parts-optional.patch
+++ b/recipes-ros/moveit/moveit-ros-perception/0001-moveit_ros_perception-make-OpenGL-parts-optional.patch
@@ -1,0 +1,106 @@
+From f86d6ca6c56d90e983a8074d4a8d6ac22cdee8cf Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Tue, 24 Jan 2017 17:27:28 +0200
+Subject: [PATCH 1/2] moveit_ros_perception: make OpenGL parts optional
+
+But build everything by default.
+
+Upstream-Status: Inappropriate [WONTFIX for stable indigo-devel branch]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ CMakeLists.txt | 35 ++++++++++++++++++++---------------
+ 1 file changed, 20 insertions(+), 15 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e984b17..fd91cc6 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,8 @@
+ cmake_minimum_required(VERSION 2.8.3)
+ project(moveit_ros_perception)
+ 
++option(BUILD_OPENGL "Build the parts that depends on OpenGL" ON)
++
+ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+   set(CMAKE_BUILD_TYPE Release)
+ endif()
+@@ -9,12 +11,16 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
+ 
+ find_package(Boost REQUIRED thread signals)
+ 
+-find_package(OpenGL REQUIRED)
+-find_package(GLEW REQUIRED)
+-find_package(GLUT REQUIRED)
+-if (OPENGL_FOUND)
+-  set(gl_LIBS ${gl_LIBS} ${OPENGL_LIBRARIES})
+-endif(OPENGL_FOUND)
++if (BUILD_OPENGL)
++  find_package(OpenGL REQUIRED)
++  find_package(GLEW REQUIRED)
++  find_package(GLUT REQUIRED)
++  if (OPENGL_FOUND)
++    set(gl_LIBS ${gl_LIBS} ${OPENGL_LIBRARIES})
++  endif(OPENGL_FOUND)
++  set(perception_GL_INCLUDE_DIRS "mesh_filter/include" "depth_image_octomap_updater/include")
++  set(SYSTEM_GL_INCLUDE_DIRS ${GLEW_INCLUDE_DIR} ${GLUT_INCLUDE_DIR})
++endif(BUILD_OPENGL)
+ 
+ find_package(catkin REQUIRED COMPONENTS
+   moveit_core
+@@ -39,13 +45,12 @@ find_package(OpenCV)
+ 
+ catkin_package(
+   INCLUDE_DIRS
+-    mesh_filter/include
+     lazy_free_space_updater/include
+-    depth_image_octomap_updater/include
+     point_containment_filter/include
+     occupancy_map_monitor/include
+     pointcloud_octomap_updater/include
+     semantic_world/include
++    ${perception_GL_INCLUDE_DIRS}
+     ${OCTOMAP_INCLUDE_DIRS}
+   LIBRARIES
+     moveit_lazy_free_space_updater
+@@ -59,21 +64,19 @@ catkin_package(
+     image_transport
+     moveit_msgs)
+ 
+-include_directories(mesh_filter/include
+-                    lazy_free_space_updater/include
+-                    depth_image_octomap_updater/include
++include_directories(lazy_free_space_updater/include
+                     point_containment_filter/include
+                     occupancy_map_monitor/include
+                     pointcloud_octomap_updater/include
+                     semantic_world/include
++                    ${perception_GL_INCLUDE_DIRS}
+                     ${OpenCV_INCLUDE_DIRS}
+                     ${Boost_INCLUDE_DIRS}
+                     ${catkin_INCLUDE_DIRS}
+                     )
+ include_directories(SYSTEM
+                     ${EIGEN_INCLUDE_DIRS}
+-                    ${GLEW_INCLUDE_DIR}
+-                    ${GLUT_INCLUDE_DIR}
++                    ${SYSTEM_GL_INCLUDE_DIR}
+                     )
+ 
+ link_directories(${Boost_LIBRARY_DIRS})
+@@ -83,8 +86,10 @@ add_subdirectory(lazy_free_space_updater)
+ add_subdirectory(point_containment_filter)
+ add_subdirectory(occupancy_map_monitor)
+ add_subdirectory(pointcloud_octomap_updater)
+-add_subdirectory(mesh_filter)
+-add_subdirectory(depth_image_octomap_updater)
++if (BUILD_OPENGL)
++  add_subdirectory(mesh_filter)
++  add_subdirectory(depth_image_octomap_updater)
++endif(BUILD_OPENGL)
+ 
+ add_subdirectory(semantic_world)
+ 
+-- 
+2.7.4
+

--- a/recipes-ros/moveit/moveit-ros-perception/0002-Add-C-11-support-for-moveit_ros_perception-and-movei.patch
+++ b/recipes-ros/moveit/moveit-ros-perception/0002-Add-C-11-support-for-moveit_ros_perception-and-movei.patch
@@ -1,0 +1,41 @@
+From c46a8ed481810a647d505139731dfa3fb1c8d657 Mon Sep 17 00:00:00 2001
+From: Dave Coleman <dave@dav.ee>
+Date: Wed, 20 Jul 2016 08:42:23 -0600
+Subject: [PATCH 2/2] Add C++11 support for moveit_ros_perception and
+ moveit_ros_robot_interaction (#721)
+
+Upstream-Status: Backported [kinetic-devel]
+---
+ CMakeLists.txt                                    | 2 ++
+ pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp       | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fd91cc6..ea040f2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,6 +3,8 @@ project(moveit_ros_perception)
+ 
+ option(BUILD_OPENGL "Build the parts that depends on OpenGL" ON)
+ 
++add_compile_options(-std=c++11)
++
+ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+   set(CMAKE_BUILD_TYPE Release)
+ endif()
+diff --git a/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp b/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+index db0b1c2..22be20a 100644
+--- a/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
++++ b/pointcloud_octomap_updater/src/pointcloud_octomap_updater.cpp
+@@ -251,7 +251,7 @@ void PointCloudOctomapUpdater::cloudMsgCallback(const sensor_msgs::PointCloud2::
+         //  continue;
+ 
+         /* check for NaN */
+-        if (!isnan(pt_iter[0]) && !isnan(pt_iter[1]) && !isnan(pt_iter[2]))
++        if (!std::isnan(pt_iter[0]) && !std::isnan(pt_iter[1]) && !std::isnan(pt_iter[2]))
+         {
+           /* transform to map frame */
+           tf::Vector3 point_tf = map_H_sensor * tf::Vector3(pt_iter[0], pt_iter[1], pt_iter[2]);
+-- 
+2.7.4
+

--- a/recipes-ros/moveit/moveit-ros-perception_0.7.8.bb
+++ b/recipes-ros/moveit/moveit-ros-perception_0.7.8.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "Components of MoveIt connecting to perception"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+
+DEPENDS = "moveit-core tf-conversions image-transport cv-bridge"
+
+require moveit-${PV}.inc
+
+ROS_BPN = "moveit_ros/perception"
+
+SRC_URI = "https://github.com/ros-planning/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz \
+           file://0001-moveit_ros_perception-make-OpenGL-parts-optional.patch \
+           file://0002-Add-C-11-support-for-moveit_ros_perception-and-movei.patch \
+           "
+EXTRA_OECMAKE_append = " -DBUILD_OPENGL=OFF"

--- a/recipes-ros/moveit/moveit-ros-planning/0001-address-gcc6-build-error.patch
+++ b/recipes-ros/moveit/moveit-ros-planning/0001-address-gcc6-build-error.patch
@@ -1,0 +1,49 @@
+From 6734257c8d611e7561372be93e31ea5c4887c7e2 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Wed, 25 Jan 2017 11:02:22 +0200
+Subject: [PATCH 1/2] address gcc6 build error
+
+With gcc6, compiling fails with `stdlib.h: No such file or directory`,
+as including '-isystem /usr/include' breaks with gcc6, cf.,
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
+
+This commit addresses this issue for this package in almost the same way
+it was addressed in various other ROS packages. A list of related
+commits and pull requests is at:
+
+    https://github.com/ros/rosdistro/issues/12783
+
+Particularly when searching for the Boost library CMake sets
+Boost_INCLUDE_DIRS to @SYSROOT@/usr/include which should be
+avoided in the `-isystem` option of gcc.
+
+Upstream-Status: Accepted
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ CMakeLists.txt | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2f41991..4829da0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -62,11 +62,12 @@ catkin_package(
+ 
+ include_directories(${THIS_PACKAGE_INCLUDE_DIRS}
+                     ${catkin_INCLUDE_DIRS}
+-		    )
++                    ${Boost_INCLUDE_DIRS}
++)
+ include_directories(SYSTEM
+                     ${EIGEN_INCLUDE_DIRS}
+-                    ${Boost_INCLUDE_DIRS}
+-                    )
++)
++
+ 
+ link_directories(${Boost_LIBRARY_DIRS})
+ link_directories(${catkin_LIBRARY_DIRS})
+-- 
+2.7.4
+

--- a/recipes-ros/moveit/moveit-ros-planning_0.7.8.bb
+++ b/recipes-ros/moveit/moveit-ros-planning_0.7.8.bb
@@ -1,0 +1,15 @@
+DESCRIPTION = "Planning components of MoveIt that use ROS"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "moveit-core moveit-ros-perception dynamic-reconfigure python-rospkg libtinyxml"
+
+require moveit-${PV}.inc
+
+ROS_BPN = "moveit_ros/planning"
+
+SRC_URI = "https://github.com/ros-planning/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz \
+           file://0001-address-gcc6-build-error.patch \
+           "
+FILES_${PN} += "${ros_libdir}/moveit_ros_planning/*"

--- a/recipes-ros/object-recognition-msgs/object-recognition-msgs_0.4.1.bb
+++ b/recipes-ros/object-recognition-msgs/object-recognition-msgs_0.4.1.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Object_recognition_msgs contains the ROS message and the actionlib definition used in object_recognition_core"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+SRC_URI = "https://github.com/wg-perception/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "c79731da116912ae8b1366aa705345ab"
+SRC_URI[sha256sum] = "b7689a079ad78a4358946fa5a38de0c9a5c12e46381d22106f053ac5cde357f1"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin
+
+ROS_SPN = "object_recognition_msgs"
+
+DEPENDS = "message-generation std-msgs geometry-msgs sensor-msgs actionlib-msgs shape-msgs"

--- a/recipes-ros/packagegroups/packagegroup-ros-world.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-world.bb
@@ -172,6 +172,7 @@ RDEPENDS_${PN} = "\
     rosbridge-server \
     rosbridge-suite \
     ar-track-alvar \
+    moveit-ros-planning \
 "
 
 # collada-parser and collada-urdf require collada-dom, which does not compile with gcc6.

--- a/recipes-ros/srdfdom/srdfdom/0001-address-gcc6-build-error.patch
+++ b/recipes-ros/srdfdom/srdfdom/0001-address-gcc6-build-error.patch
@@ -1,0 +1,46 @@
+From 5571eaff800b8be87add3436507659b5e166ab9c Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Fri, 20 Jan 2017 11:29:58 +0200
+Subject: [PATCH] address gcc6 build error
+
+With gcc6, compiling fails with `stdlib.h: No such file or directory`,
+as including '-isystem /usr/include' breaks with gcc6, cf.,
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
+
+This commit addresses this issue for this package in the same way
+it was addressed in various other ROS packages. A list of related
+commits and pull requests is at:
+
+  https://github.com/ros/rosdistro/issues/12783
+
+Upstream-Status: Backported [from kinetic-devel]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ CMakeLists.txt | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index a28ecea..545934b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
+ project(srdfdom)
+ 
+ find_package(Boost REQUIRED)
+-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
+ 
+ find_package(console_bridge REQUIRED)
+ find_package(urdfdom_headers REQUIRED)
+@@ -11,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS cmake_modules urdfdom_py)
+ 
+ find_package(TinyXML REQUIRED)
+ 
+-include_directories(include ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
++include_directories(include ${Boost_INCLUDE_DIR} ${TinyXML_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS} ${urdfdom_headers_INCLUDE_DIRS})
+ link_directories(${catkin_LIBRARY_DIRS})
+ 
+ catkin_python_setup()
+-- 
+2.7.4
+

--- a/recipes-ros/srdfdom/srdfdom_0.3.5.bb
+++ b/recipes-ros/srdfdom/srdfdom_0.3.5.bb
@@ -1,0 +1,18 @@
+DESCRIPTION = "Parser for Semantic Robot Description Format"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "cmake-modules boost urdf urdfdom-py console-bridge libtinyxml urdfdom-headers"
+
+SRC_URI = "https://github.com/ros-planning/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz \
+           file://0001-address-gcc6-build-error.patch \
+           "
+SRC_URI[md5sum] = "1b35fc7d120a8dbf41ede3c03c88ca5e"
+SRC_URI[sha256sum] = "9018c7c4da88e406e5059f0e2013049dfa4c04980f42a311c1201748ba5ba1de"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin
+
+ROS_SPN = "srdfdom"


### PR DESCRIPTION
Particularly this commit brings in

* moveit_core;
* moveit_ros_perception;
* moveit_ros_planning;
* moveit_msgs

and their build dependencies like

* object_recognition_msgs;
* srdfdom.

Also they are included into packagegroup-ros-world.bb.