### PR TITLE
kobuki recipes

### DIFF
--- a/recipes-extended/kdl/python-orocos-kdl_1.3.0.bb
+++ b/recipes-extended/kdl/python-orocos-kdl_1.3.0.bb
@@ -1,9 +1,9 @@
 DESCRIPTION = "This package contains the python bindings PyKDL for the Kinematics and Dynamics Library (KDL), distributed by the Orocos Project."
 SECTION = "devel"
 LICENSE = "LGPLv2"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=46ee8693f40a89a31023e97ae17ecf19"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=46ee8693f40a89a31023e97ae17ecf19"
 
-DEPENDS = "sip-native python-sip orocos-kdl"
+DEPENDS = "sip-native sip orocos-kdl"
 
 require kdl.inc
 

--- a/recipes-extended/sophus/sophus_0.9.1.bb
+++ b/recipes-extended/sophus/sophus_0.9.1.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "C++ implementation of Lie Groups using Eigen."
+SECTION = "devel"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://sophus/sophus.hpp;beginline=5;endline=21;md5=4cb78e93094b91e5b1616cb93ab7e635"
+
+DEPENDS = "libeigen"
+
+SRC_URI = "https://github.com/stonier/sophus/archive/${PV}.tar.gz;;downloadfilename=${PN}_${PV}.tar.gz"
+SRC_URI[md5sum] = "de77d9f4b769df91bd57c5224f7f1b88"
+SRC_URI[sha256sum] = "962165b5233c5d4b4d1f6c36ea77e6f3d004b9fff907f617f9952f84534177cc"
+
+S = "${WORKDIR}/sophus-${PV}"
+
+inherit cmake
+
+# CXXFLAGS are needed to compile eigen 3.3.1 headers properly
+CXXFLAGS += "-Wno-deprecated-declarations -Wno-misleading-indentation"

--- a/recipes-ros/capabilities/capabilities_0.2.0.bb
+++ b/recipes-ros/capabilities/capabilities_0.2.0.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Package which implements capabilities"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=62135a7570582b9018c89013d4815380"
+
+DEPENDS = "message-generation roslaunch rospy std-msgs std-srvs"
+
+SRC_URI = "https://github.com/osrf/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "0071ef2532612c7cc60c2b5a423d38d6"
+SRC_URI[sha256sum] = "e55564dd82373139a4758d9d9e85d697bed6a0487c018774913e0f7069ce4024"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin
+
+RDEPENDS_${PN} = "bondpy message-runtime nodelet python-pyyaml roslaunch"

--- a/recipes-ros/ecl-core/ecl-command-line_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-command-line_0.61.17.bb
@@ -1,0 +1,9 @@
+DESCRIPTION = "Embeds the TCLAP library inside the ecl. This is a very convenient \
+  command line parser in templatised c++."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-concepts_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-concepts_0.61.17.bb
@@ -1,0 +1,9 @@
+DESCRIPTION = "Introduces a compile time concept checking mechanism that can be used \
+  most commonly to check for required functionality when passing template arguments."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config ecl-type-traits"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-containers_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-containers_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "The containers included here are intended to extend the stl containers."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config ecl-errors ecl-exceptions ecl-formatters ecl-converters ecl-mpl ecl-type-traits ecl-utilities"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-converters_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-converters_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Some fast/convenient type converters, mostly for char strings or strings."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config ecl-errors ecl-exceptions ecl-mpl ecl-type-traits ecl-concepts"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-core-apps_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-core-apps_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "This includes a suite of programs demo'ing various aspects of the ecl_core."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-license ecl-config ecl-linear-algebra ecl-command-line ecl-converters ecl-containers ecl-devices ecl-errors ecl-exceptions ecl-formatters ecl-geometry ecl-ipc ecl-sigslots ecl-streams ecl-threads ecl-type-traits ecl-time-lite"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-core.inc
+++ b/recipes-ros/ecl-core/ecl-core.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/stonier/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "625fa08e6e23adb58d9de2caaaf2be08"
+SRC_URI[sha256sum] = "ea2e3e8e7572d6e18374b8be3736ce4761ea1f18c6af046af3fe4fcaadfc5285"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "ecl_core"

--- a/recipes-ros/ecl-core/ecl-devices_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-devices_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Provides an extensible and standardised framework for input-output devices."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config ecl-errors ecl-mpl ecl-type-traits ecl-utilities ecl-containers ecl-threads"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-eigen_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-eigen_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "This provides an Eigen implementation for ecl's linear algebra."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "cmake-modules ecl-license libeigen"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-exceptions_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-exceptions_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Template based exceptions - these are simple and practical and avoid the proliferation of exception types."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config ecl-errors"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-filesystem_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-filesystem_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Cross platform filesystem utilities (until c++11 makes its way in)."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-build ecl-config ecl-errors ecl-exceptions"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-formatters_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-formatters_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "The formatters here simply format various input types to a specified text format."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config ecl-exceptions ecl-converters"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-geometry_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-geometry_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Any tools relating to mathematical geometry."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-license ecl-config ecl-type-traits ecl-containers ecl-formatters ecl-linear-algebra ecl-exceptions ecl-math ecl-mpl"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-ipc_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-ipc_0.61.17.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "This package provides an infrastructure to allow for developing \
+  cross platform c++ wrappers around the lower level c api's that handle these \
+  mechanisms."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-build ecl-config ecl-errors ecl-time-lite ecl-exceptions ecl-time"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-linear-algebra_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-linear-algebra_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Ecl frontend to a linear matrix package (currently eigen)."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-converters ecl-eigen ecl-exceptions ecl-formatters ecl-license ecl-math sophus"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-math_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-math_0.61.17.bb
@@ -1,0 +1,9 @@
+DESCRIPTION = "This package provides simple support to cmath, filling in holes \
+  or redefining in a c++ formulation where desirable."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-type-traits"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-mpl_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-mpl_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Metaprogramming tools move alot of runtime calculations to be shifted to compile time."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-sigslots_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-sigslots_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Provides a signal/slot mechanism."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config ecl-threads"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-statistics_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-statistics_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Common statistical structures and algorithms for control systems."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-license ecl-config ecl-linear-algebra"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-streams_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-streams_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "These are lightweight text streaming classes that connect to standardised ecl type devices."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-errors ecl-concepts ecl-devices ecl-time ecl-converters ecl-type-traits"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-threads_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-threads_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "This package provides the c++ extensions for a variety of threaded programming tools."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-build ecl-config ecl-errors ecl-concepts ecl-exceptions ecl-time ecl-utilities"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-time_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-time_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "This package provides a means for handling different timing models."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-build ecl-config ecl-errors ecl-exceptions ecl-time-lite"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-type-traits_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-type-traits_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Extends c++ type traits and implements a few more to boot."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config ecl-mpl"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-core/ecl-utilities_0.61.17.bb
+++ b/recipes-ros/ecl-core/ecl-utilities_0.61.17.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Includes various supporting tools and utilities for c++ programming."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-mpl ecl-concepts"
+
+require ecl-core.inc

--- a/recipes-ros/ecl-lite/ecl-config_0.61.6.bb
+++ b/recipes-ros/ecl-lite/ecl-config_0.61.6.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "These tools inspect and describe your system with macros, types and functions."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-license"
+
+require ecl-lite.inc

--- a/recipes-ros/ecl-lite/ecl-console_0.61.6.bb
+++ b/recipes-ros/ecl-lite/ecl-console_0.61.6.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Color codes for ansii consoles."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-license ecl-config"
+
+require ecl-lite.inc

--- a/recipes-ros/ecl-lite/ecl-converters-lite_0.61.6.bb
+++ b/recipes-ros/ecl-lite/ecl-converters-lite_0.61.6.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "These are a very simple version of some of the functions in ecl_converters suitable for firmware development."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config"
+
+require ecl-lite.inc

--- a/recipes-ros/ecl-lite/ecl-errors_0.61.6.bb
+++ b/recipes-ros/ecl-lite/ecl-errors_0.61.6.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "This library provides lean and mean error mechanisms."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config"
+
+require ecl-lite.inc

--- a/recipes-ros/ecl-lite/ecl-io_0.61.6.bb
+++ b/recipes-ros/ecl-lite/ecl-io_0.61.6.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Most implementations (windows, posix, ...) have slightly different api for low level input-output functions."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config ecl-errors"
+
+require ecl-lite.inc

--- a/recipes-ros/ecl-lite/ecl-lite.inc
+++ b/recipes-ros/ecl-lite/ecl-lite.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/stonier/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "0f2fe9ce82d783593a92e0677dcdcda6"
+SRC_URI[sha256sum] = "b8a02aabecc9a47bde44c83c7e02669e7ce9a3e43f51315b89d10960ed83f3cc"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "ecl_lite"

--- a/recipes-ros/ecl-lite/ecl-sigslots-lite_0.61.6.bb
+++ b/recipes-ros/ecl-lite/ecl-sigslots-lite_0.61.6.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "This avoids use of dynamic storage (malloc/new) and thread \
+  safety (mutexes) to provide a very simple sigslots implementation that can \
+  be used for *very* embedded development."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license ecl-config ecl-errors"
+
+require ecl-lite.inc

--- a/recipes-ros/ecl-lite/ecl-time-lite_0.61.6.bb
+++ b/recipes-ros/ecl-lite/ecl-time-lite_0.61.6.bb
@@ -1,0 +1,9 @@
+DESCRIPTION = "Provides a portable set of time functions that are especially \
+  useful for porting other code or being wrapped by higher level c++ classes."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-license ecl-config ecl-errors"
+
+require ecl-lite.inc

--- a/recipes-ros/ecl-navigation/ecl-mobile-robot_0.60.3.bb
+++ b/recipes-ros/ecl-navigation/ecl-mobile-robot_0.60.3.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "Contains transforms (e.g. differential drive inverse kinematics) for the various types of mobile robot platforms."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-license ecl-errors ecl-geometry ecl-math ecl-formatters ecl-linear-algebra"
+
+SRC_URI = "https://github.com/stonier/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "2a3b92362b366cd2b08188c43a51dcbd"
+SRC_URI[sha256sum] = "2b5798d37508600ffc5285c4a4e319cd5ad49cac78ed59b216f033a8e9a8cc2e"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "ecl_navigation"

--- a/recipes-ros/ecl-tools/ecl-build_0.61.6.bb
+++ b/recipes-ros/ecl-tools/ecl-build_0.61.6.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Collection of cmake/make build tools primarily for ecl development itself"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-license"
+
+require ecl-tools.inc

--- a/recipes-ros/ecl-tools/ecl-license_0.61.6.bb
+++ b/recipes-ros/ecl-tools/ecl-license_0.61.6.bb
@@ -1,0 +1,7 @@
+DESCRIPTION = "Maintains the ecl licenses and also provides an install target \
+  for deploying licenses with the ecl libraries."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+require ecl-tools.inc

--- a/recipes-ros/ecl-tools/ecl-tools.inc
+++ b/recipes-ros/ecl-tools/ecl-tools.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/stonier/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "f4c840f4336bda84b201aa820e285b6b"
+SRC_URI[sha256sum] = "8004f61d183369ccbb1daebae86f207e91c0161629d41e6113c1aacc8cee332d"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "ecl_tools"

--- a/recipes-ros/kobuki-core/kobuki-core.inc
+++ b/recipes-ros/kobuki-core/kobuki-core.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/yujinrobot/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "2aa8afbfbc61473a541633afa761fac9"
+SRC_URI[sha256sum] = "a1fe0af70d9b694354058824fdc53055acd77d60519879d10fbd932f88c7dd04"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "kobuki_core"

--- a/recipes-ros/kobuki-core/kobuki-dock-drive_0.6.5.bb
+++ b/recipes-ros/kobuki-core/kobuki-dock-drive_0.6.5.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Dock driving library for Kobuki."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-threads ecl-geometry ecl-linear-algebra"
+
+require kobuki-core.inc

--- a/recipes-ros/kobuki-core/kobuki-driver_0.6.5.bb
+++ b/recipes-ros/kobuki-core/kobuki-driver_0.6.5.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "C++ driver library for Kobuki"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-mobile-robot ecl-converters ecl-devices ecl-geometry ecl-sigslots ecl-time ecl-command-line"
+
+require kobuki-core.inc

--- a/recipes-ros/kobuki-msgs/kobuki-msgs_0.6.1.bb
+++ b/recipes-ros/kobuki-msgs/kobuki-msgs_0.6.1.bb
@@ -1,0 +1,15 @@
+DESCRIPTION = "Kobuki message and service types: custom messages and services for Kobuki packages."
+AUTHOR = "Daniel Stonier"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "std-msgs actionlib-msgs message-generation"
+
+SRC_URI = "https://github.com/yujinrobot/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "9a2ebd9de77d546636027b9ddeb5dd84"
+SRC_URI[sha256sum] = "e8814159bec34b707936c69d06ca68eef02b5859f449b3c917ec236bf44cfaf9"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin

--- a/recipes-ros/kobuki/kobuki-auto-docking_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-auto-docking_0.6.8.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Automatic docking for Kobuki"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp rospy nodelet pluginlib message-filters actionlib \
+  kdl-conversions std-msgs nav-msgs geometry-msgs actionlib-msgs kobuki-msgs \
+  kobuki-dock-drive ecl-threads ecl-geometry ecl-linear-algebra"
+
+require kobuki.inc

--- a/recipes-ros/kobuki/kobuki-bumper2pc_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-bumper2pc_0.6.8.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Bumper/cliff to pointcloud nodelet"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp nodelet pluginlib kobuki-msgs sensor-msgs"
+
+require kobuki.inc

--- a/recipes-ros/kobuki/kobuki-capabilities_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-capabilities_0.6.8.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Kobuki's capabilities"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+require kobuki.inc
+
+RDEPENDS_${PN} = "kobuki-node nodelet rocon-app-manager rocon-apps std-capabilities"

--- a/recipes-ros/kobuki/kobuki-controller-tutorial_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-controller-tutorial_0.6.8.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Code for the Kobuki controller tutorial."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp nodelet pluginlib std-msgs kobuki-msgs yocs-controllers"
+
+require kobuki.inc

--- a/recipes-ros/kobuki/kobuki-description_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-description_0.6.8.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Description of the Kobuki model"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=17;endline=17;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "urdf xacro"
+
+require kobuki.inc

--- a/recipes-ros/kobuki/kobuki-keyop_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-keyop_0.6.8.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Keyboard teleoperation for Kobuki"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp geometry-msgs std-srvs std-msgs ecl-exceptions ecl-threads ecl-time kobuki-msgs"
+
+require kobuki.inc

--- a/recipes-ros/kobuki/kobuki-node_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-node_0.6.8.bb
@@ -1,0 +1,9 @@
+DESCRIPTION = "ROS nodelet for Kobuki: ROS wrapper for the Kobuki driver"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp geometry-msgs sensor-msgs nav-msgs std-msgs tf angles diagnostic-updater diagnostic-msgs nodelet pluginlib \
+  kobuki-msgs kobuki-driver kobuki-keyop kobuki-safety-controller ecl-exceptions ecl-sigslots ecl-streams ecl-threads"
+
+require kobuki.inc

--- a/recipes-ros/kobuki/kobuki-random-walker_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-random-walker_0.6.8.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Random walker app for Kobuki"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-threads geometry-msgs kobuki-msgs nodelet pluginlib roscpp std-msgs yocs-controllers"
+
+require kobuki.inc

--- a/recipes-ros/kobuki/kobuki-rapps_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-rapps_0.6.8.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Robot apps for Kobuki"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+require kobuki.inc
+
+RDEPENDS_${PN} = "kobuki-auto-docking kobuki-random-walker nodelet"

--- a/recipes-ros/kobuki/kobuki-safety-controller_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-safety-controller_0.6.8.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "A controller ensuring the safe operation of Kobuki."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=15;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp nodelet pluginlib std-msgs geometry-msgs kobuki-msgs yocs-controllers ecl-threads"
+
+require kobuki.inc

--- a/recipes-ros/kobuki/kobuki-testsuite_0.6.8.bb
+++ b/recipes-ros/kobuki/kobuki-testsuite_0.6.8.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Kobuki test suite"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "python-orocos-kdl kobuki-node std-msgs sensor-msgs geometry-msgs kobuki-msgs message-generation"
+
+require kobuki.inc

--- a/recipes-ros/kobuki/kobuki.inc
+++ b/recipes-ros/kobuki/kobuki.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/yujinrobot/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "47c5451f1f0db1dd980c2e804b78a285"
+SRC_URI[sha256sum] = "d0b51e309d57852fc63a63b4070031857515eff1e9f7693df174f134ef4f049e"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "kobuki"

--- a/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
@@ -38,4 +38,22 @@ RDEPENDS_${PN} = "\
     ecl-time-lite \
     ecl-type-traits \
     ecl-utilities \
+    yocs-ar-marker-tracking \
+    yocs-ar-pair-approach \
+    yocs-ar-pair-tracking \
+    yocs-cmd-vel-mux \
+    yocs-controllers \
+    yocs-diff-drive-pose-controller \
+    yocs-joyop \
+    yocs-keyop \
+    yocs-localization-manager \
+    yocs-math-toolkit \
+    yocs-msgs \
+    yocs-navigator \
+    yocs-rapps \
+    yocs-safety-controller \
+    yocs-velocity-smoother \
+    yocs-virtual-sensor \
+    yocs-waypoint-provider \
+    yocs-waypoints-navi \
 "

--- a/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
@@ -63,4 +63,37 @@ RDEPENDS_${PN} = "\
     zeroconf-avahi \
     zeroconf-avahi-demos \
     zeroconf-msgs \
+    concert-msgs \
+    concert-service-msgs \
+    concert-workflow-engine-msgs \
+    gateway-msgs \
+    rocon-app-manager \
+    rocon-app-manager-msgs \
+    rocon-apps \
+    rocon-app-utilities \
+    rocon-bubble-icons \
+    rocon-console \
+    rocon-device-msgs \
+    rocon-ebnf \
+    rocon-gateway \
+    rocon-gateway-tests \
+    rocon-gateway-utils \
+    rocon-hub \
+    rocon-hub-client \
+    rocon-icons \
+    rocon-interaction-msgs \
+    rocon-interactions \
+    rocon-launch \
+    rocon-master-info \
+    rocon-python-comms \
+    rocon-python-redis \
+    rocon-python-utils \
+    rocon-python-wifi \
+    rocon-semantic-version \
+    rocon-service-pair-msgs \
+    rocon-std-msgs \
+    rocon-test \
+    rocon-tutorial-msgs \
+    rocon-uri \
+    scheduler-msgs \
 "

--- a/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
@@ -1,0 +1,41 @@
+DESCRIPTION = "ros-kobuki package group"
+LICENSE = "MIT"
+
+inherit packagegroup
+
+PACKAGES = "${PN}"
+
+RDEPENDS_${PN} = "\
+    ecl-build \
+    ecl-command-line \
+    ecl-concepts \
+    ecl-config \
+    ecl-console \
+    ecl-containers \
+    ecl-converters \
+    ecl-converters-lite \
+    ecl-core-apps \
+    ecl-devices \
+    ecl-eigen \
+    ecl-errors \
+    ecl-exceptions \
+    ecl-filesystem \
+    ecl-formatters \
+    ecl-geometry \
+    ecl-io \
+    ecl-ipc \
+    ecl-license \
+    ecl-linear-algebra \
+    ecl-math \
+    ecl-mobile-robot \
+    ecl-mpl \
+    ecl-sigslots \
+    ecl-sigslots-lite \
+    ecl-statistics \
+    ecl-streams \
+    ecl-threads \
+    ecl-time \
+    ecl-time-lite \
+    ecl-type-traits \
+    ecl-utilities \
+"

--- a/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
@@ -96,4 +96,19 @@ RDEPENDS_${PN} = "\
     rocon-tutorial-msgs \
     rocon-uri \
     scheduler-msgs \
+    kobuki-auto-docking \
+    kobuki-bumper2pc \
+    kobuki-capabilities \
+    kobuki-controller-tutorial \
+    kobuki-description \
+    kobuki-dock-drive \
+    kobuki-driver \
+    kobuki-keyop \
+    kobuki-msgs \
+    kobuki-node \
+    kobuki-random-walker \
+    kobuki-rapps \
+    kobuki-safety-controller \
 "
+
+# kobuki-testsuite depends on python-orocos-kdl; python-orocos-kdl fails with #469.

--- a/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
@@ -56,4 +56,8 @@ RDEPENDS_${PN} = "\
     yocs-virtual-sensor \
     yocs-waypoint-provider \
     yocs-waypoints-navi \
+    capabilities \
+    std-capabilities \
+    unique-id \
+    uuid-msgs \
 "

--- a/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-kobuki.bb
@@ -60,4 +60,7 @@ RDEPENDS_${PN} = "\
     std-capabilities \
     unique-id \
     uuid-msgs \
+    zeroconf-avahi \
+    zeroconf-avahi-demos \
+    zeroconf-msgs \
 "

--- a/recipes-ros/packagegroups/packagegroup-ros-world.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-world.bb
@@ -7,6 +7,7 @@ PACKAGES = "${PN}"
 
 RDEPENDS_${PN} = "\
     packagegroup-ros-comm \
+    packagegroup-ros-kobuki \
     actionlib \
     bond \
     bondcpp \

--- a/recipes-ros/rocon-app-platform/rocon-app-manager_0.7.13.bb
+++ b/recipes-ros/rocon-app-platform/rocon-app-manager_0.7.13.bb
@@ -1,0 +1,13 @@
+DESCRIPTION = "The public interface and retaskable interface for a robot."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roslint"
+
+require rocon-app-platform.inc
+
+RDEPENDS_${PN} = "capabilities gateway-msgs rocon-app-manager-msgs rocon-app-utilities \
+  rocon-apps rocon-console rocon-gateway-utils rocon-gateway rocon-hub rocon-interactions \
+  rocon-master-info rocon-python-comms rocon-python-utils rocon-std-msgs rocon-uri \
+  roslib rosmaster rospy std-msgs"

--- a/recipes-ros/rocon-app-platform/rocon-app-platform.inc
+++ b/recipes-ros/rocon-app-platform/rocon-app-platform.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/robotics-in-concert/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "defca2d4c405502249bd4888bee837f6"
+SRC_URI[sha256sum] = "72eae53692744d04d580a549449d5346edf28a67f25265db3ba371f467b0a03a"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "rocon_app_platform"

--- a/recipes-ros/rocon-app-platform/rocon-app-utilities_0.7.13.bb
+++ b/recipes-ros/rocon-app-platform/rocon-app-utilities_0.7.13.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "The rocon_app_utilities package"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg roslint"
+
+require rocon-app-platform.inc
+
+RDEPENDS_${PN} = "rocon-console rocon-python-utils rocon-uri ${PYTHON_PN}-rospkg roslaunch"

--- a/recipes-ros/rocon-app-platform/rocon-apps_0.7.13.bb
+++ b/recipes-ros/rocon-app-platform/rocon-apps_0.7.13.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Core rocon apps for use with the appmanager and rocon concert."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+require rocon-app-platform.inc
+
+RDEPENDS_${PN} = "bash gateway-msgs rocon-app-manager-msgs roslib rospy rospy-tutorials topic-tools"

--- a/recipes-ros/rocon-msgs/concert-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/concert-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Shared communication types for the concert framework."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation std-msgs uuid-msgs gateway-msgs rocon-app-manager-msgs rocon-std-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-msgs/concert-service-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/concert-service-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Messages used by official rocon services."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation rocon-service-pair-msgs rocon-std-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-msgs/concert-workflow-engine-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/concert-workflow-engine-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Messages used by workflow engine"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation std-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-msgs/gateway-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/gateway-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Messages used by the gateway model."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation std-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-msgs/rocon-app-manager-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/rocon-app-manager-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Messages used by the platform app manager."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation rocon-std-msgs rocon-service-pair-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-msgs/rocon-device-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/rocon-device-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Messages used by rocon devices"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation std-msgs rocon-std-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-msgs/rocon-interaction-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/rocon-interaction-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Messages used by rocon interactions"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation rocon-std-msgs uuid-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-msgs/rocon-msgs.inc
+++ b/recipes-ros/rocon-msgs/rocon-msgs.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/robotics-in-concert/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "9cf381dfbcddfd11a7237719b94c2250"
+SRC_URI[sha256sum] = "47b7f4dcac0c260bcbe4428032968b4c52476bf37ac43be67bcda4cd1699fce0"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "rocon_msgs"

--- a/recipes-ros/rocon-msgs/rocon-service-pair-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/rocon-service-pair-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Paired pubsubs generators for non-blocking services."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation uuid-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-msgs/rocon-std-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/rocon-std-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Standard messages used by other rocon specific package types."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation std-msgs rocon-service-pair-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-msgs/rocon-tutorial-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/rocon-tutorial-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Messages used by rocon tutorials."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation rocon-service-pair-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-msgs/scheduler-msgs_0.7.12.bb
+++ b/recipes-ros/rocon-msgs/scheduler-msgs_0.7.12.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Messages used by the rocon scheduler."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "message-generation std-msgs rocon-std-msgs uuid-msgs"
+
+require rocon-msgs.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/rocon-multimaster/rocon-gateway-tests_0.7.10.bb
+++ b/recipes-ros/rocon-multimaster/rocon-gateway-tests_0.7.10.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Testing programs for gateways."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "rocon-test"
+
+require rocon-multimaster.inc

--- a/recipes-ros/rocon-multimaster/rocon-gateway-utils_0.7.10.bb
+++ b/recipes-ros/rocon-multimaster/rocon-gateway-utils_0.7.10.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Utilities for gateway users (avoids large dependency requirements)."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+require rocon-multimaster.inc
+
+RDEPENDS_${PN} = "rosgraph gateway-msgs rocon-console rocon-python-comms rosservice"

--- a/recipes-ros/rocon-multimaster/rocon-gateway_0.7.10.bb
+++ b/recipes-ros/rocon-multimaster/rocon-gateway_0.7.10.bb
@@ -1,0 +1,13 @@
+DESCRIPTION = "A hub acts as a shared key-value store for multiple ros systems (primarily used by gateways)."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roslint"
+
+require rocon-multimaster.inc
+
+RDEPENDS_${PN} = "gateway-msgs python-cryptography rospy rocon-hub-client \
+  rocon-console rocon-python-comms rocon-python-redis rocon-gateway-utils \
+  rocon-python-utils rocon-python-wifi roslib rostopic rosservice rosgraph \
+  std-srvs zeroconf-msgs zeroconf-avahi"

--- a/recipes-ros/rocon-multimaster/rocon-hub-client_0.7.10.bb
+++ b/recipes-ros/rocon-multimaster/rocon-hub-client_0.7.10.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Client api for discovery and connection to rocon hubs."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+require rocon-multimaster.inc
+
+RDEPENDS_${PN} = "gateway-msgs rospy rocon-python-redis rocon-gateway-utils"

--- a/recipes-ros/rocon-multimaster/rocon-hub_0.7.10.bb
+++ b/recipes-ros/rocon-multimaster/rocon-hub_0.7.10.bb
@@ -1,0 +1,11 @@
+DESCRIPTION = "A hub acts as a shared key-value store for multiple ros systems (primarily used by gateways)."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roslint"
+
+require rocon-multimaster.inc
+
+RDEPENDS_${PN} = "avahi-daemon avahi-utils redis std-srvs rosgraph rocon-console \
+  rocon-gateway rocon-python-comms rocon-python-redis rocon-semantic-version"

--- a/recipes-ros/rocon-multimaster/rocon-multimaster.inc
+++ b/recipes-ros/rocon-multimaster/rocon-multimaster.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/robotics-in-concert/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "1b48d8efe8c69eeecc90a0e53329e8ac"
+SRC_URI[sha256sum] = "eb5806aaab740a202c3e0f9f1899c9b5ce57cd8353f88028e95aa0bc2d966659"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "rocon_multimaster"

--- a/recipes-ros/rocon-multimaster/rocon-test_0.7.10.bb
+++ b/recipes-ros/rocon-multimaster/rocon-test_0.7.10.bb
@@ -1,0 +1,11 @@
+DESCRIPTION = "Rocon test framework (i.e. multi-launch rostest framework)."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "rostest"
+
+require rocon-multimaster.inc
+
+RDEPENDS_${PN} = "rospy rostest rosunit rocon-console rocon-python-utils \
+  roslaunch rocon-launch"

--- a/recipes-ros/rocon-tools/rocon-bubble-icons_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-bubble-icons_0.1.23.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Bubble icon library for rocon."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg"
+
+require rocon-tools.inc

--- a/recipes-ros/rocon-tools/rocon-console_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-console_0.1.23.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Command line python console utilities (mostly for colourisation)."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg"
+
+require rocon-tools.inc

--- a/recipes-ros/rocon-tools/rocon-ebnf_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-ebnf_0.1.23.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Internal packaging of the 0.91 version of the simple python EBNF parser written by LParis."
+SECTION = "devel"
+LICENSE = "GPL"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=162b49cfbae9eadf37c9b89b2d2ac6be"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg"
+
+require rocon-tools.inc

--- a/recipes-ros/rocon-tools/rocon-icons_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-icons_0.1.23.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Icons for rocon"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg"
+
+require rocon-tools.inc

--- a/recipes-ros/rocon-tools/rocon-interactions_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-interactions_0.1.23.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "Interaction management for human interactive agents in the concert."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg roslint"
+
+require rocon-tools.inc
+
+RDEPENDS_${PN} = "genpy ${PYTHON_PN}-rospkg rospy rocon-bubble-icons rocon-console rocon-icons \
+  rocon-app-manager-msgs rocon-interaction-msgs rocon-python-comms rocon-python-utils \
+  rocon-std-msgs rocon-uri std-msgs unique-id"

--- a/recipes-ros/rocon-tools/rocon-launch_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-launch_0.1.23.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "A multi-roslaunch (for single and multi-master systems)."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg"
+
+require rocon-tools.inc
+
+RDEPENDS_${PN} = "rospy roslaunch rocon-console rocon-python-utils rosbash"

--- a/recipes-ros/rocon-tools/rocon-master-info_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-master-info_0.1.23.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Publish master information - name, description, icon."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg"
+
+require rocon-tools.inc
+
+RDEPENDS_${PN} = "rospy rocon-console rocon-icons rocon-python-comms rocon-python-utils rocon-std-msgs"

--- a/recipes-ros/rocon-tools/rocon-python-comms_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-python-comms_0.1.23.bb
@@ -1,0 +1,11 @@
+DESCRIPTION = "Service pair libraries for pub/sub non-blocking services."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg"
+
+require rocon-tools.inc
+
+RDEPENDS_${PN} = "genpy rospy rosnode rosservice rostopic rosgraph roslib python-pyyaml \
+  rocon-console rocon-service-pair-msgs unique-id uuid-msgs"

--- a/recipes-ros/rocon-tools/rocon-python-redis_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-python-redis_0.1.23.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Locally patched version of the python redis client (https://github.com/andymccurdy/redis-py)."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg"
+
+require rocon-tools.inc

--- a/recipes-ros/rocon-tools/rocon-python-utils_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-python-utils_0.1.23.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Python system and ros utilities."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg"
+
+require rocon-tools.inc
+
+RDEPENDS_${PN} = "${PYTHON_PN}-rospkg ${PYTHON_PN}-catkin-pkg rospy rocon-std-msgs roslib"

--- a/recipes-ros/rocon-tools/rocon-python-wifi_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-python-wifi_0.1.23.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Copy of the pythonwifi package re-packaged and distributed in rocon_tools for use in ROS"
+SECTION = "devel"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=fe8b75cf0aba647401e1038bcd69ee74"
+
+DEPENDS = "${PYTHON_PN}-catkin-pkg"
+
+require rocon-tools.inc

--- a/recipes-ros/rocon-tools/rocon-semantic-version_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-semantic-version_0.1.23.bb
@@ -1,0 +1,6 @@
+DESCRIPTION = "Internal packaging of the 2.2.2 version of the python semantic version module."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+require rocon-tools.inc

--- a/recipes-ros/rocon-tools/rocon-tools.inc
+++ b/recipes-ros/rocon-tools/rocon-tools.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/robotics-in-concert/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "32191c042411a5af1dd584453a57cf78"
+SRC_URI[sha256sum] = "14f8b3d42a343fd1ef7be4e9756fc47b1bb2714f2068f8509e6f51086945a356"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "rocon_tools"

--- a/recipes-ros/rocon-tools/rocon-uri_0.1.23.bb
+++ b/recipes-ros/rocon-tools/rocon-uri_0.1.23.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Module for working with rocon uri strings."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+require rocon-tools.inc
+
+RDEPENDS_${PN} = "rocon-console rocon-ebnf rospy"

--- a/recipes-ros/std-capabilities/std-capabilities_0.1.0.bb
+++ b/recipes-ros/std-capabilities/std-capabilities_0.1.0.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "Repository of standard capability interfaces."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=6b38617620548d973af8c0de66615e95"
+
+SRC_URI = "https://github.com/osrf/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "c0ae69fddd03051cba41142349c05b2d"
+SRC_URI[sha256sum] = "77cd3d4ab0022929ac4f68be64aad311ccc19b082228629ca7d0315fd088b158"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin

--- a/recipes-ros/unique-identifier/unique-id_1.0.5.bb
+++ b/recipes-ros/unique-identifier/unique-id_1.0.5.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "ROS Python and C++ interfaces for universally unique identifiers."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp rospy uuid-msgs"
+
+require unique-identifier.inc

--- a/recipes-ros/unique-identifier/unique-identifier.inc
+++ b/recipes-ros/unique-identifier/unique-identifier.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/ros-geographic-info/${ROS_SPN}/archive/${ROS_SPN}-${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "6c04f7238aae651cfb3daa97c018232d"
+SRC_URI[sha256sum] = "70f3fc1e8b81ce2a80383fe1bec69dd0760913852a78ff1d010e6a1c2baa1d3c"
+
+S = "${WORKDIR}/${ROS_SPN}-${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "unique_identifier"

--- a/recipes-ros/unique-identifier/uuid-msgs_1.0.5.bb
+++ b/recipes-ros/unique-identifier/uuid-msgs_1.0.5.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "ROS messages for universally unique identifiers."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "message-generation std-msgs"
+
+require unique-identifier.inc
+
+RDEPENDS_${PN} = "message-runtime"

--- a/recipes-ros/yocs-msgs/yocs-msgs_0.6.3.bb
+++ b/recipes-ros/yocs-msgs/yocs-msgs_0.6.3.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "Yujin's Open Control System messages, services and actions"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "actionlib-msgs std-msgs std-srvs geometry-msgs message-generation dynamic-reconfigure"
+
+SRC_URI = "https://github.com/yujinrobot/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "aa6d653e6f54fe01c7214008b67cadd2"
+SRC_URI[sha256sum] = "df0d541cd0752e444965e52980ba999e5c47e3d455caa0362d4cf9d75be8cccc"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin

--- a/recipes-ros/yujin-ocs/yocs-ar-marker-tracking_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-ar-marker-tracking_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Collecting, tracking and generating statistics for ar markers from ar_track_alvar."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ar-track-alvar-msgs roscpp geometry-msgs sensor-msgs yaml-cpp yocs-math-toolkit"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-ar-pair-approach_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-ar-pair-approach_0.6.4.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Search and approach behaviour, moving to a target in front of a pair of ar markers."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "dynamic-reconfigure geometry-msgs rospy std-msgs tf"
+
+require yujin-ocs.inc
+
+RDEPENDS_${PN} = "bash"

--- a/recipes-ros/yujin-ocs/yocs-ar-pair-tracking_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-ar-pair-tracking_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "The AR pair tracking package."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp std-msgs geometry-msgs sensor-msgs yocs-math-toolkit ar-track-alvar-msgs yocs-ar-marker-tracking yocs-msgs"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-cmd-vel-mux_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-cmd-vel-mux_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "A multiplexer for command velocity inputs."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp nodelet dynamic-reconfigure pluginlib geometry-msgs yaml-cpp ${PYTHON_PN}-rospkg"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-controllers_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-controllers_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Library for various controller types and algorithms"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-diff-drive-pose-controller_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-diff-drive-pose-controller_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "A controller for driving a differential drive base to a pose goal or along a path specified by multiple poses."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-threads geometry-msgs nodelet pluginlib roscpp sensor-msgs std-msgs tf yocs-controllers yocs-math-toolkit"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-joyop_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-joyop_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Joystick teleoperation for your robot core"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp geometry-msgs sensor-msgs std-msgs yocs-msgs ecl-exceptions ecl-time"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-keyop_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-keyop_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Keyboard teleoperation for your robot"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp geometry-msgs std-msgs ecl-exceptions ecl-threads ecl-time"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-localization-manager_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-localization-manager_0.6.4.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Localization Manager helps to localize robot's position with annotated information"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roslint"
+
+require yujin-ocs.inc
+
+RDEPENDS_${PN} = "rospy actionlib ar-track-alvar ar-track-alvar-msgs geometry-msgs std-msgs yocs-msgs dynamic-reconfigure tf"

--- a/recipes-ros/yujin-ocs/yocs-math-toolkit_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-math-toolkit_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Math toolkit for Yujin open control system."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-build ecl-config ecl-exceptions ecl-formatters ecl-linear-algebra geometry-msgs roscpp tf"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-navigator_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-navigator_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Navigation module for robots"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "rospy roscpp actionlib tf yocs-math-toolkit move-base-msgs nav-msgs yocs-msgs"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-rapps_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-rapps_0.6.4.bb
@@ -1,0 +1,6 @@
+DESCRIPTION = "Yujin open control system rapps for use with the app manager and rocon concert"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-safety-controller_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-safety-controller_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "A controller ensuring the safe operation of your robot."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "ecl-threads geometry-msgs nodelet pluginlib roscpp sensor-msgs std-msgs yocs-controllers"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-velocity-smoother_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-velocity-smoother_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Bound incoming velocity messages according to robot velocity and acceleration limits."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp pluginlib nodelet geometry-msgs nav-msgs ecl-threads dynamic-reconfigure ${PYTHON_PN}-rospkg"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-virtual-sensor_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-virtual-sensor_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Virtual sensor that uses semantic map information to see obstacles undetectable by robot sensors."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "tf roscpp sensor-msgs geometry-msgs yocs-msgs yocs-math-toolkit"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-waypoint-provider/0001-yocs_waypoint_provider-also-install-libraries.patch
+++ b/recipes-ros/yujin-ocs/yocs-waypoint-provider/0001-yocs_waypoint_provider-also-install-libraries.patch
@@ -1,0 +1,56 @@
+From 6492044a8c7c5c285962c104217111716fd7bb78 Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
+Date: Tue, 3 Jan 2017 11:17:10 +0100
+Subject: [PATCH] yocs_waypoint_provider: also install libraries
+
+To provide a package where all needed content is installed, also
+the two libraries waypoint_provider_lib and
+way_provider_yaml_parser_lib that are required by the
+waypoint_provider executable must be installed.
+
+I became aware of this issue when creating bitbake recipes for the
+yocs_waypoint_provider package in the OpenEmbedded layer for ROS [1].
+The bitbake tool chain reported the following warnings for the
+yocs_waypoint_provider 0.6.4, shipped in the indigo distribution:
+```
+WARNING: yocs-waypoint-provider-0.6.4-r0 do_package_qa: QA Issue: /opt/ros/indigo/lib/yocs_waypoint_provider/waypoint_provider contained in package yocs-waypoint-provider requires libwaypoint_provider_lib.so, but no providers found in RDEPENDS_yocs-waypoint-provider? [file-rdeps]
+WARNING: yocs-waypoint-provider-0.6.4-r0 do_package_qa: QA Issue: /opt/ros/indigo/lib/yocs_waypoint_provider/waypoint_provider contained in package yocs-waypoint-provider requires libwaypoint_provider_yaml_parser_lib.so, but no providers found in RDEPENDS_yocs-waypoint-provider? [file-rdeps]
+```
+These two warnings pointed out that the two libraries in
+yocs_waypoint_provider were not installed.
+
+[1] https://github.com/bmwcarit/meta-ros
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+
+Upstream-Status: Accepted [https://github.com/yujinrobot/yujin_ocs/commit/60c1d5d1046217836aa926e3b8e491c737f8d93e]
+
+This patch has been generated with:
+  `git format-patch -1 6492044a8c7c5c285962c104217111716fd7bb78`
+in the yujin_ocs repository.
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ yocs_waypoint_provider/CMakeLists.txt | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/yocs_waypoint_provider/CMakeLists.txt b/yocs_waypoint_provider/CMakeLists.txt
+index 13c7ae2..f736e78 100644
+--- a/yocs_waypoint_provider/CMakeLists.txt
++++ b/yocs_waypoint_provider/CMakeLists.txt
+@@ -38,6 +38,12 @@ target_link_libraries(waypoint_provider waypoint_provider_lib waypoint_provider_
+ ## Install ##
+ #############
+ 
++install(TARGETS waypoint_provider_lib waypoint_provider_yaml_parser_lib
++  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
++  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
++  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
++)
++
+ install(TARGETS waypoint_provider 
+         DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+ )
+-- 
+2.5.5
+

--- a/recipes-ros/yujin-ocs/yocs-waypoint-provider_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-waypoint-provider_0.6.4.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Parse a multiple poses from yaml and provide as topic and service."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "roscpp visualization-msgs yocs-msgs geometry-msgs yaml-cpp"
+
+require yujin-ocs.inc
+
+SRC_URI += "file://0001-yocs_waypoint_provider-also-install-libraries.patch;striplevel=2"

--- a/recipes-ros/yujin-ocs/yocs-waypoints-navi_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-waypoints-navi_0.6.4.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Simple tool for waypoints navigation"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "tf roscpp actionlib nav-msgs geometry-msgs move-base-msgs actionlib-msgs visualization-msgs yocs-math-toolkit yocs-msgs"
+
+require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yujin-ocs.inc
+++ b/recipes-ros/yujin-ocs/yujin-ocs.inc
@@ -1,0 +1,9 @@
+SRC_URI = "https://github.com/yujinrobot/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "bd996001ff36fc07b470d9695ce81414"
+SRC_URI[sha256sum] = "3ecc6a3f59c007921369a7542be69121801635421dcedab2528d4298f339f838"
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "yujin_ocs"

--- a/recipes-ros/zeroconf-avahi-suite/files/0001-address-gcc6-build-error.patch
+++ b/recipes-ros/zeroconf-avahi-suite/files/0001-address-gcc6-build-error.patch
@@ -1,0 +1,63 @@
+From aa0fce16bc80ce7a890dc63b380462f3819cf5e0 Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
+Date: Sat, 14 Jan 2017 06:42:53 +0100
+Subject: [PATCH] address gcc6 build error
+
+With gcc6, compiling fails with `stdlib.h: No such file or directory`,
+as including '-isystem /usr/include' breaks with gcc6, cf.,
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
+
+This commit addresses this issue for this package in the same way
+it was addressed in various other ROS packages. A list of related
+commits and pull requests is at:
+
+  https://github.com/ros/rosdistro/issues/12783
+
+The SYSTEM attribute for the include directories was added in commit
+188f8fe9 on 2012-11-10 when the packages were changed to use catkin as
+build system. The exact reason for using the SYSTEM attribute cannot be
+inferred from that commit.
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
+
+Upstream-Status: Accepted [https://github.com/stonier/zeroconf_avahi_suite/pull/6/commits/aa0fce16bc80ce7a890dc63b380462f3819cf5e0]
+
+This patch has been generated with:
+  `git format-patch -1 aa0fce16bc80ce7a890dc63b380462f3819cf5e0`
+in the zeroconf_avahi_suite repository.
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@oss.bmw-carit.de>
+---
+ zeroconf_avahi/CMakeLists.txt       | 2 +-
+ zeroconf_avahi_demos/CMakeLists.txt | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/zeroconf_avahi/CMakeLists.txt b/zeroconf_avahi/CMakeLists.txt
+index 7a05c7c..ec1a48a 100644
+--- a/zeroconf_avahi/CMakeLists.txt
++++ b/zeroconf_avahi/CMakeLists.txt
+@@ -21,7 +21,7 @@ catkin_package(
+   CATKIN_DEPENDS rosconsole roscpp zeroconf_msgs 
+   DEPENDS Boost
+ )
+-include_directories(SYSTEM include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDES} ${AVAHI_INCLUDE_DIR})
++include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDES} ${AVAHI_INCLUDE_DIR})
+ 
+ ##############################################################################
+ # Project
+diff --git a/zeroconf_avahi_demos/CMakeLists.txt b/zeroconf_avahi_demos/CMakeLists.txt
+index c558870..17495a4 100644
+--- a/zeroconf_avahi_demos/CMakeLists.txt
++++ b/zeroconf_avahi_demos/CMakeLists.txt
+@@ -15,7 +15,7 @@ find_package(catkin REQUIRED COMPONENTS zeroconf_avahi zeroconf_msgs)
+ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${zeroconf_avahi_DIR})
+ find_package(Avahi REQUIRED)
+ catkin_package()
+-include_directories(SYSTEM include ${catkin_INCLUDE_DIRS} ${AVAHI_INCLUDE_DIR})
++include_directories(include ${catkin_INCLUDE_DIRS} ${AVAHI_INCLUDE_DIR})
+ 
+ ##############################################################################
+ # Project
+-- 
+2.5.5
+

--- a/recipes-ros/zeroconf-avahi-suite/zeroconf-avahi-demos_0.2.3.bb
+++ b/recipes-ros/zeroconf-avahi-suite/zeroconf-avahi-demos_0.2.3.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Several demos and launch-tests for the avahi based zero-configuration."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "zeroconf-msgs zeroconf-avahi"
+
+require zeroconf-avahi-suite.inc
+
+RDEPENDS_${PN} = "avahi-daemon bash"

--- a/recipes-ros/zeroconf-avahi-suite/zeroconf-avahi-suite.inc
+++ b/recipes-ros/zeroconf-avahi-suite/zeroconf-avahi-suite.inc
@@ -1,0 +1,11 @@
+SRC_URI = "https://github.com/stonier/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "b0212776e9c4ae69800a0a4a06e0ad25"
+SRC_URI[sha256sum] = "37c1a7febd79ce67cf03f6bbf69dd839ca1efe576b46f22ff6a4ca66e7f8a791"
+
+SRC_URI += "file://0001-address-gcc6-build-error.patch;patchdir=.."
+
+S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
+
+inherit catkin
+
+ROS_SPN = "zeroconf_avahi_suite"

--- a/recipes-ros/zeroconf-avahi-suite/zeroconf-avahi_0.2.3.bb
+++ b/recipes-ros/zeroconf-avahi-suite/zeroconf-avahi_0.2.3.bb
@@ -1,0 +1,8 @@
+DESCRIPTION = "Provides zeroconf services on avahi for ros systems."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "rosconsole roscpp zeroconf-msgs avahi"
+
+require zeroconf-avahi-suite.inc

--- a/recipes-ros/zeroconf-msgs/zeroconf-msgs_0.2.1.bb
+++ b/recipes-ros/zeroconf-msgs/zeroconf-msgs_0.2.1.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "General ros communications used by the various zeroconf implementations."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=5ee5b8b046ae48ad94a2037ca953a67b"
+
+DEPENDS = "std-msgs message-generation"
+
+SRC_URI = "https://github.com/stonier/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "38e89e637f855c2ea0e8cb65c02dfd08"
+SRC_URI[sha256sum] = "a5bfd788bc2e2aefb07cb3a302a25cbeef2ce7e931a3a273cb1ae9669645a696"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin


### PR DESCRIPTION
This is the set of recipes for the kobuki packages. It is almost ready to be merged.
Commit a6dcf9c and cead3ed are only in place, as I am working on a6dcf9c in the branch complete-packagegroup, but I assume I can drop those two commits once the complete-packagegroup is merged.
This pull request is large, and it is ready for testing and review.
Currently, I am only aware of one error that python-orocos-kdl does not compile due to some problem with including eigen, which I only became aware with the very recent versions of master. The python-orocos-kdl recipe did work in January 2017.