### PR TITLE
catkin: drop redundant build dependency on python-empy

### DIFF
--- a/recipes-ros/catkin/catkin.inc
+++ b/recipes-ros/catkin/catkin.inc
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cmake python-empy python-catkin-pkg python-empy-native python-catkin-pkg-native"
+DEPENDS = "cmake python-catkin-pkg python-empy-native python-catkin-pkg-native"
 
 SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "d58460cc9112812d8c4e6ecf98bbcc85"


### PR DESCRIPTION
It's enough to have python-empy-native in the build dependencies
of catkin and catkin-runtime. If we ever support on target
development then python-empy should be better added to
catkin's run-time dependencies.