### PR TITLE
Remove rostest dependencies

### DIFF
--- a/recipes-ros/cv-camera/cv-camera/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/cv-camera/cv-camera/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -1,0 +1,36 @@
+From 92cea9b1a2267dadb0b7e2409ed8a23531fad0cf Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+Date: Mon, 3 Apr 2017 18:01:56 +0200
+Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
+
+Upstream-Status: Accepted [https://github.com/OTL/cv_camera/commit/92cea9b1a2267dadb0b7e2409ed8a23531fad0cf]
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fc6a658..681c64b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
+ project(cv_camera)
+ 
+ find_package(catkin REQUIRED COMPONENTS
+-  image_transport roscpp cv_bridge sensor_msgs nodelet camera_info_manager rostest roslint)
++  image_transport roscpp cv_bridge sensor_msgs nodelet camera_info_manager roslint)
+ 
+ find_package(OpenCV REQUIRED)
+ 
+@@ -86,6 +86,7 @@ roslint_cpp(
+   )
+ 
+ if (CATKIN_ENABLE_TESTING)
++  find_package(rostest REQUIRED)
+   add_rostest_gtest(test_cv_camera test/cv_camera.test
+     test/test_cv_camera.cpp)
+   target_link_libraries(test_cv_camera ${PROJECT_NAME} ${catkin_LIBRARIES})
+-- 
+2.5.5
+

--- a/recipes-ros/cv-camera/cv-camera_0.1.0.bb
+++ b/recipes-ros/cv-camera/cv-camera_0.1.0.bb
@@ -3,11 +3,13 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "opencv image-transport roscpp cv-bridge sensor-msgs nodelet camera-info-manager rostest roslint"
+DEPENDS = "opencv image-transport roscpp cv-bridge sensor-msgs nodelet camera-info-manager roslint"
 
 SRC_URI = "https://github.com/OTL/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "d52b7c7386615d649cb7c0a83b910845"
 SRC_URI[sha256sum] = "f38948e279e79a7410abb341e1313a64cd8edff2e0a3086d2045a86741af14bf"
+
+SRC_URI += "file://0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch"
 
 S = "${WORKDIR}/${ROS_SP}"
 

--- a/recipes-ros/diagnostics/diagnostic-aggregator_1.8.10.bb
+++ b/recipes-ros/diagnostics/diagnostic-aggregator_1.8.10.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "bondcpp bondpy diagnostic-msgs pluginlib roscpp rospy rostest xmlrpcpp"
+DEPENDS = "bondcpp bondpy diagnostic-msgs pluginlib roscpp rospy xmlrpcpp"
 
 require diagnostics.inc

--- a/recipes-ros/diagnostics/diagnostic-analysis_1.8.10.bb
+++ b/recipes-ros/diagnostics/diagnostic-analysis_1.8.10.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "diagnostic-msgs rosbag roslib rostest"
+DEPENDS = "diagnostic-msgs rosbag roslib"
 
 require diagnostics.inc

--- a/recipes-ros/diagnostics/diagnostic-updater_1.8.10.bb
+++ b/recipes-ros/diagnostics/diagnostic-updater_1.8.10.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "diagnostic-msgs roscpp rostest std-msgs"
+DEPENDS = "diagnostic-msgs roscpp std-msgs"
 
 require diagnostics.inc

--- a/recipes-ros/diagnostics/diagnostics.inc
+++ b/recipes-ros/diagnostics/diagnostics.inc
@@ -2,6 +2,8 @@ SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilena
 SRC_URI[md5sum] = "34bb53fbcf57924cc2c15e185451869b"
 SRC_URI[sha256sum] = "9f2c6012f60e55e7735ba2d08dbc9bcd96f09ca9d3df223a0f1966bdab454dea"
 
+SRC_URI += "file://0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch;patchdir=.."
+
 S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
 
 inherit catkin

--- a/recipes-ros/diagnostics/files/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/diagnostics/files/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -1,0 +1,77 @@
+From aa8052e042192946386d2c564baa1883c4866593 Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+Date: Wed, 5 Apr 2017 10:58:34 +0200
+Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
+
+Upstream-Status: Submitted [https://github.com/ros/diagnostics/pull/60]
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ diagnostic_aggregator/CMakeLists.txt | 3 ++-
+ diagnostic_analysis/CMakeLists.txt   | 3 ++-
+ diagnostic_updater/CMakeLists.txt    | 3 ++-
+ 3 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/diagnostic_aggregator/CMakeLists.txt b/diagnostic_aggregator/CMakeLists.txt
+index 5995f67..1660d94 100644
+--- a/diagnostic_aggregator/CMakeLists.txt
++++ b/diagnostic_aggregator/CMakeLists.txt
+@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.3)
+ project(diagnostic_aggregator)
+ 
+ # Load catkin and all dependencies required for this package
+-find_package(catkin REQUIRED diagnostic_msgs pluginlib roscpp rospy rostest xmlrpcpp bondcpp)
++find_package(catkin REQUIRED diagnostic_msgs pluginlib roscpp rospy xmlrpcpp bondcpp)
+ catkin_package(DEPENDS diagnostic_msgs pluginlib roscpp rospy xmlrpcpp bondcpp bondpy
+     INCLUDE_DIRS include
+     LIBRARIES ${PROJECT_NAME})
+@@ -46,6 +46,7 @@ add_executable(analyzer_loader test/analyzer_loader.cpp
+ target_link_libraries(analyzer_loader diagnostic_aggregator)
+ 
+ if(CATKIN_ENABLE_TESTING)
++  find_package(rostest REQUIRED)
+   add_rostest(test/launch/test_agg.launch)
+   add_rostest(test/launch/test_add_agg.launch)
+ 
+diff --git a/diagnostic_analysis/CMakeLists.txt b/diagnostic_analysis/CMakeLists.txt
+index c20c24c..eb8cf64 100644
+--- a/diagnostic_analysis/CMakeLists.txt
++++ b/diagnostic_analysis/CMakeLists.txt
+@@ -2,11 +2,12 @@ cmake_minimum_required(VERSION 2.8.3)
+ project(diagnostic_analysis)
+ 
+ # Load catkin and all dependencies required for this package
+-find_package(catkin REQUIRED diagnostic_msgs rosbag roslib rostest)
++find_package(catkin REQUIRED diagnostic_msgs rosbag roslib)
+ 
+ catkin_package(DEPENDS diagnostic_msgs rosbag roslib)
+ 
+ if(CATKIN_ENABLE_TESTING)
++  find_package(rostest REQUIRED)
+   catkin_add_nosetests(test/bag_csv_test.py)
+ endif()
+ 
+diff --git a/diagnostic_updater/CMakeLists.txt b/diagnostic_updater/CMakeLists.txt
+index 72f7af0..7dae0a1 100644
+--- a/diagnostic_updater/CMakeLists.txt
++++ b/diagnostic_updater/CMakeLists.txt
+@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
+ project(diagnostic_updater)
+ 
+ # Load catkin and all dependencies required for this package
+-find_package(catkin REQUIRED diagnostic_msgs roscpp rostest std_msgs)
++find_package(catkin REQUIRED diagnostic_msgs roscpp std_msgs)
+ 
+ catkin_python_setup()
+ 
+@@ -15,6 +15,7 @@ add_executable(example src/example.cpp)
+ target_link_libraries(example ${catkin_LIBRARIES})
+ 
+ if(CATKIN_ENABLE_TESTING)
++  find_package(rostest REQUIRED)
+   add_rostest_gtest(diagnostic_updater_test test/diagnostic_updater_test.xml test/diagnostic_updater_test.cpp)
+   add_rostest(test/diagnostic_updater_fast_test.xml)
+   target_link_libraries(diagnostic_updater_test ${catkin_LIBRARIES})
+-- 
+2.5.5
+

--- a/recipes-ros/executive-smach/smach-ros/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/executive-smach/smach-ros/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -1,0 +1,36 @@
+From 9835342260d40cfeb4d062be1d6ddcc85c5037d8 Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+Date: Tue, 4 Apr 2017 11:43:26 +0200
+Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
+
+Upstream-Status: Submitted [https://github.com/ros/executive_smach/pull/45]
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ smach_ros/CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/smach_ros/CMakeLists.txt b/smach_ros/CMakeLists.txt
+index e5694b1..f409e2e 100644
+--- a/smach_ros/CMakeLists.txt
++++ b/smach_ros/CMakeLists.txt
+@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
+ 
+ project(smach_ros)
+ 
+-find_package(catkin REQUIRED COMPONENTS rostest)
++find_package(catkin REQUIRED)
+ 
+ catkin_python_setup()
+ 
+@@ -11,6 +11,7 @@ catkin_package(
+ )
+ 
+ if(CATKIN_ENABLE_TESTING)
++  find_package(rostest REQUIRED)
+   add_rostest(test/state_machine.test)
+   add_rostest(test/sequence.test)
+   add_rostest(test/concurrence.test)
+-- 
+2.5.5
+

--- a/recipes-ros/executive-smach/smach-ros_2.0.0.bb
+++ b/recipes-ros/executive-smach/smach-ros_2.0.0.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=17;endline=17;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "rostest"
-
 require executive-smach.inc
+
+SRC_URI += "file://0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch;striplevel=2"

--- a/recipes-ros/navigation/base-local-planner/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/navigation/base-local-planner/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -1,0 +1,35 @@
+From e6f3979ff8b988fe7992bf08a8267f1e11f58627 Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+Date: Tue, 4 Apr 2017 14:39:25 +0200
+Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
+
+Upstream-Status: Submitted [https://github.com/ros-planning/navigation/pull/565]
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ base_local_planner/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/base_local_planner/CMakeLists.txt b/base_local_planner/CMakeLists.txt
+index 2444ae1..507af18 100644
+--- a/base_local_planner/CMakeLists.txt
++++ b/base_local_planner/CMakeLists.txt
+@@ -10,7 +10,6 @@ find_package(catkin REQUIRED
+             dynamic_reconfigure
+             nav_core
+             pcl_conversions
+-            rostest
+             costmap_2d
+             pluginlib
+             angles
+@@ -129,6 +128,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
+ )
+ 
+ if(CATKIN_ENABLE_TESTING)
++  find_package(rostest)
+   catkin_add_gtest(base_local_planner_utest
+     test/gtest_main.cpp
+     test/utest.cpp
+-- 
+2.5.5
+

--- a/recipes-ros/navigation/base-local-planner_1.12.13.bb
+++ b/recipes-ros/navigation/base-local-planner_1.12.13.bb
@@ -6,6 +6,8 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=01c2bc31767cc
 
 DEPENDS = "angles costmap-2d dynamic-reconfigure geometry-msgs libeigen message-generation \
     nav-core nav-msgs pcl-conversions pcl-ros pluginlib rosconsole roscpp rospy std-msgs tf \
-    voxel-grid visualization-msgs rostest"
+    voxel-grid visualization-msgs"
 
 require navigation.inc
+
+SRC_URI += "file://0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch;striplevel=2"

--- a/recipes-ros/robot-state-publisher/robot-state-publisher/0001-Make-rostest-dependency-conditional-depending-on-CAT.patch
+++ b/recipes-ros/robot-state-publisher/robot-state-publisher/0001-Make-rostest-dependency-conditional-depending-on-CAT.patch
@@ -1,0 +1,63 @@
+From f3f1c4d55c6f707685f727c80d3e04bbb37be8ed Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Javier=20V=2E=20G=C3=B3mez?= <engjotauve@gmail.com>
+Date: Wed, 16 Nov 2016 19:54:30 +0100
+Subject: [PATCH 1/3] Make rostest dependency conditional, depending on
+ CATKIN_ENABLE_TESTING (#66)
+
+* Make rostest dependency conditional, depending on CATKIN_ENABLE_TESTING
+
+* Make rostest dependency REQUIRED
+
+Upstream-Status: Backport [https://github.com/ros/robot_state_publisher/commit/f3f1c4d55c6f707685f727c80d3e04bbb37be8ed]
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ CMakeLists.txt | 4 +++-
+ package.xml    | 3 +--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 11ea778..0510171 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -3,7 +3,7 @@ project(robot_state_publisher)
+ 
+ find_package(orocos_kdl REQUIRED)
+ find_package(catkin REQUIRED
+-  COMPONENTS roscpp rosconsole rostime tf tf2_ros tf2_kdl kdl_parser cmake_modules rostest
++  COMPONENTS roscpp rosconsole rostime tf tf2_ros tf2_kdl kdl_parser cmake_modules
+ )
+ find_package(Eigen REQUIRED)
+ 
+@@ -33,6 +33,8 @@ target_link_libraries(state_publisher ${PROJECT_NAME}_solver ${orocos_kdl_LIBRAR
+ 
+ if (CATKIN_ENABLE_TESTING)
+ 
++  find_package(rostest REQUIRED)
++
+   add_rostest_gtest(test_one_link ${CMAKE_CURRENT_SOURCE_DIR}/test/test_one_link.launch test/test_one_link.cpp)
+   target_link_libraries(test_one_link ${catkin_LIBRARIES} ${PROJECT_NAME}_solver)
+ 
+diff --git a/package.xml b/package.xml
+index 793a235..1eea965 100644
+--- a/package.xml
++++ b/package.xml
+@@ -26,7 +26,6 @@
+   <build_depend version_gte="1.3.0">orocos_kdl</build_depend>
+   <build_depend>rosconsole</build_depend>
+   <build_depend>roscpp</build_depend>
+-  <build_depend>rostest</build_depend>
+   <build_depend>rostime</build_depend>
+   <build_depend>sensor_msgs</build_depend>
+   <build_depend>tf</build_depend>
+@@ -47,6 +46,6 @@
+   <run_depend>tf2_kdl</run_depend>
+   <run_depend>tf_conversions</run_depend>
+ 
+-  <build_depend>rostest</build_depend>
++  <test_depend>rostest</test_depend>
+ 
+ </package>
+-- 
+2.5.5
+

--- a/recipes-ros/robot-state-publisher/robot-state-publisher_1.11.2.bb
+++ b/recipes-ros/robot-state-publisher/robot-state-publisher_1.11.2.bb
@@ -3,11 +3,13 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=18;endline=18;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cmake-modules libeigen kdl-parser orocos-kdl rosconsole roscpp rostime sensor-msgs tf tf2-ros tf2-kdl rostest"
+DEPENDS = "cmake-modules libeigen kdl-parser orocos-kdl rosconsole roscpp rostime sensor-msgs tf tf2-ros tf2-kdl"
 
 SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "f10d326400fd97f349a19a330c65aa3a"
 SRC_URI[sha256sum] = "33b7606f0ea913e22887fe30521c94c1167f56197c03ce2985fc778876ea2141"
+
+SRC_URI += "file://0001-Make-rostest-dependency-conditional-depending-on-CAT.patch"
 
 S = "${WORKDIR}/${ROS_SP}"
 

--- a/recipes-ros/rosauth/rosauth/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/rosauth/rosauth/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -1,0 +1,36 @@
+From b63fb159dcf85f450c5770f55f57b281ab9cce68 Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+Date: Tue, 4 Apr 2017 06:04:39 +0200
+Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
+
+Upstream-Status: Submitted [https://github.com/GT-RAIL/rosauth/pull/11]
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d45c59..434e6ce 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,7 +4,7 @@ project(rosauth)
+ ## Find catkin macros and libraries
+ ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+ ## is used, also find other catkin packages
+-find_package(catkin REQUIRED COMPONENTS roscpp message_generation rostest)
++find_package(catkin REQUIRED COMPONENTS roscpp message_generation)
+ 
+ #######################################
+ ## Declare ROS messages and services ##
+@@ -62,6 +62,7 @@ install(TARGETS ros_mac_authentication
+ #############
+ 
+ if(CATKIN_ENABLE_TESTING)
++  find_package(rostest)
+   ## Add gtest based cpp test target and link libraries
+   add_executable(ros_mac_authentication_test test/ros_mac_authentication_test.cpp)
+   add_dependencies(ros_mac_authentication_test ${PROJECT_NAME}_gencpp)
+-- 
+2.5.5
+

--- a/recipes-ros/rosauth/rosauth_0.1.7.bb
+++ b/recipes-ros/rosauth/rosauth_0.1.7.bb
@@ -3,11 +3,13 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "roscpp rostest"
+DEPENDS = "roscpp"
 
 SRC_URI = "https://github.com/WPI-RAIL/rosauth/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "0e165e867239157266aa2e4c192244bf"
 SRC_URI[sha256sum] = "c85c4163c94d20bce9864180785210bfe3dfd110114f18212bd711d1be87c48e"
+
+SRC_URI += "file://0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch"
 
 S = "${WORKDIR}/${ROS_SP}"
 

--- a/recipes-ros/slam-gmapping/gmapping/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/slam-gmapping/gmapping/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -1,0 +1,36 @@
+From 52605268cc37e6e765b2168f41c77d430dde7e51 Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+Date: Mon, 3 Apr 2017 17:44:07 +0200
+Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
+
+Upstream-Status: Submitted [https://github.com/ros-perception/slam_gmapping/pull/48]
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ gmapping/CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gmapping/CMakeLists.txt b/gmapping/CMakeLists.txt
+index 209d4f3..42388fa 100644
+--- a/gmapping/CMakeLists.txt
++++ b/gmapping/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ cmake_minimum_required(VERSION 2.8)
+ project(gmapping)
+ 
+-find_package(catkin REQUIRED nav_msgs openslam_gmapping roscpp rostest tf rosbag_storage)
++find_package(catkin REQUIRED nav_msgs openslam_gmapping roscpp tf rosbag_storage)
+ 
+ find_package(Boost REQUIRED signals)
+ 
+@@ -33,6 +33,7 @@ install(TARGETS slam_gmapping slam_gmapping_replay
+ )
+ 
+ if(CATKIN_ENABLE_TESTING)
++  find_package(rostest REQUIRED)
+   if(TARGET tests)
+     add_executable(gmapping-rtest EXCLUDE_FROM_ALL test/rtest.cpp)
+     target_link_libraries(gmapping-rtest ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+-- 
+2.5.5
+

--- a/recipes-ros/slam-gmapping/gmapping_1.3.8.bb
+++ b/recipes-ros/slam-gmapping/gmapping_1.3.8.bb
@@ -3,11 +3,13 @@ SECTION = "devel"
 LICENSE = "CC-BY-NC-SA-2.0"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=11e24f757f025b2cbebd5b14b4a7ca19"
 
-DEPENDS = "nav-msgs openslam-gmapping roscpp rostest tf rosbag-storage"
+DEPENDS = "nav-msgs openslam-gmapping roscpp tf rosbag-storage"
 
 SRC_URI = "https://github.com/ros-perception/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "e0735400fdf9353665361eb232a6aa4a"
 SRC_URI[sha256sum] = "027e31fbe6d8768a746b0eeb93238459b295b15efc0f43f9410afc57d71385d1"
+
+SRC_URI += "file://0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch;striplevel=2"
 
 S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
 


### PR DESCRIPTION
This pull request removes the rostest dependency from all recipes in meta-ros. It was motivated by the reported issues #404 and #445, and now resolves #404 and resolves #445. This is a logical continuation of the effort in #239.