### PR TITLE
robot-model: adjust recipes missed in latest indigo update

### DIFF
--- a/recipes-ros/robot-model/collada-parser_1.11.13.bb
+++ b/recipes-ros/robot-model/collada-parser_1.11.13.bb
@@ -5,8 +5,8 @@ parser when working with Collada robot descriptions, the preferred user \
 API is found in the urdf package."
 SECTION = "devel"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=15;md5=d566ef916e9dedc494f5f793a6690ba5"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=19;endline=19;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "collada-dom roscpp urdfdom-headers urdf-parser-plugin class-loader"
+DEPENDS = "collada-dom roscpp urdfdom-headers urdf urdf-parser-plugin class-loader"
 
 require robot-model.inc

--- a/recipes-ros/robot-model/collada-urdf_1.11.13.bb
+++ b/recipes-ros/robot-model/collada-urdf_1.11.13.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "This package contains a tool to convert Unified Robot Description
 documents into COLLAborative Design Activity (COLLADA) documents."
 SECTION = "devel"
 LICENSE = "BSD"
-LIC_FILES_CHKSUM = "file://package.xml;beginline=16;endline=16;md5=d566ef916e9dedc494f5f793a6690ba5"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=18;endline=18;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 DEPENDS = "angles assimp resource-retriever collada-dom collada-parser roscpp urdf geometric-shapes tf libtinyxml"
 


### PR DESCRIPTION
I only discovered the issues in the two recipes just shortly after the merge, and after I merged the pending pull requests in a local repository and made a test build.