### PR TITLE
log4cxx: fetch with git instead of svn

### DIFF
--- a/recipes-devtools/log4cxx/log4cxx_git.bb
+++ b/recipes-devtools/log4cxx/log4cxx_git.bb
@@ -5,10 +5,10 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 HOMEPAGE = "http://logging.apache.org/log4cxx/"
 
-SRC_URI = "svn://svn.apache.org/repos/asf;module=incubator/log4cxx/trunk;protocol=http"
-SRCREV = "1738416"
+SRC_URI = "git://git-wip-us.apache.org/repos/asf/logging-log4cxx.git;protocol=http"
+SRCREV = "03c581216a469eb2bc5cabaa686199504d257af0"
 
-S = "${WORKDIR}/incubator/log4cxx/trunk"
+S = "${WORKDIR}/git"
 
 inherit autotools-brokensep pkgconfig
 


### PR DESCRIPTION
Recently, the log4cxx development version is not only provided through a svn repository, but also provided through a git repository.

In the past, various meta-ros users reported some issues (#413, #470, #483) when fetching log4cxx from the svn repository, probably due to the non-standard handling of http/https proxy in the svn client.

I expect that fetching from git causes less issues than from svn. So, the log4cxx recipe now makes bitbake fetch the sources from the git repository instead of the svn repository. Furthermore, this
commit updates the source revision to the currently latest commit.

@rojkov Please review, test and merge.