### PR TITLE
rosserial-python: Added python-pyserial to RDEPENDS

### DIFF
--- a/recipes-ros/rosserial/rosserial-python_0.6.4.bb
+++ b/recipes-ros/rosserial/rosserial-python_0.6.4.bb
@@ -5,4 +5,4 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9de
 
 require rosserial.inc
 
-RDEPENDS_${PN} = "rosserial-msgs diagnostic-msgs"
+RDEPENDS_${PN} = "rosserial-msgs diagnostic-msgs ${PYTHON_PN}-pyserial"


### PR DESCRIPTION
python-pyserial is a runtime dependency of rosserial-python, but was not added yet.