### PR TITLE
Add more MoveIt recipes and their dependencies

### DIFF
--- a/recipes-extended/ompl/ompl/0001-address-gcc6-build-error.patch
+++ b/recipes-extended/ompl/ompl/0001-address-gcc6-build-error.patch
@@ -1,0 +1,40 @@
+From 3658bb95c120228cac55cd10e4103ababf30474b Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Tue, 23 May 2017 10:01:06 +0300
+Subject: [PATCH 1/2] address gcc6 build error
+
+With gcc6, compiling fails with `stdlib.h: No such file or directory`,
+as including '-isystem /usr/include' breaks with gcc6, cf.,
+https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129.
+
+This commit addresses this issue for this package in almost the same way
+it was addressed in various other ROS packages. A list of related
+commits and pull requests is at:
+
+    https://github.com/ros/rosdistro/issues/12783
+
+Particularly when searching for the Boost library CMake sets
+Boost_INCLUDE_DIRS to @SYSROOT@/usr/include which should be
+avoided in the `-isystem` option of gcc.
+
+Upstream-Status: Submitted [https://github.com/ompl/ompl/pull/101]
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 46ae14d..be53fac 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -74,7 +74,7 @@ else()
+   # don't use chrono
+   find_package(Boost COMPONENTS date_time thread serialization filesystem system program_options unit_test_framework REQUIRED)
+ endif()
+-include_directories(SYSTEM ${Boost_INCLUDE_DIR})
++include_directories(${Boost_INCLUDE_DIR})
+ 
+ if(${Boost_VERSION} LESS 105300)
+   # Include bundled version of boost::odeint if it isn't installed natively
+-- 
+2.9.3
+

--- a/recipes-extended/ompl/ompl/0002-Add-option-to-skip-setting-RPATH.patch
+++ b/recipes-extended/ompl/ompl/0002-Add-option-to-skip-setting-RPATH.patch
@@ -1,0 +1,46 @@
+From 99bfeffe5e80f3b48f82bfff336aca3e97bc19b7 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Tue, 23 May 2017 10:24:37 +0300
+Subject: [PATCH 2/2] Add option to skip setting RPATH
+
+OMPL installs to /usr/lib by default and some projects integrating
+OMPL trigger a QA check suggesting that the set RPATH is useless.
+For example Yocto gives this warning:
+
+    QA Issue: ompl: /work/corei7-64-refkit-linux/ompl/1.1.0-r0/packages-split/ompl/usr/lib/libompl.so.1.1.0 contains probably-redundant RPATH /usr/lib [useless-rpaths]
+
+Add the option OMPL_SKIP_RPATH that helps to skip setting RPATH
+for the library. By default the option is OFF.
+
+Upstream-Status: Submitted [https://github.com/ompl/ompl/pull/101]
+---
+ CMakeModules/CompilerSettings.cmake | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeModules/CompilerSettings.cmake b/CMakeModules/CompilerSettings.cmake
+index ecef2db..65e3f45 100644
+--- a/CMakeModules/CompilerSettings.cmake
++++ b/CMakeModules/CompilerSettings.cmake
+@@ -47,11 +47,14 @@ if((CMAKE_COMPILER_IS_GNUCXX OR IS_ICPC) AND NOT MINGW)
+     add_definitions(-fPIC)
+ endif((CMAKE_COMPILER_IS_GNUCXX OR IS_ICPC) AND NOT MINGW)
+ 
+-# Set rpath http://www.paraview.org/Wiki/CMake_RPATH_handling
+-set(CMAKE_SKIP_BUILD_RPATH FALSE)
+-set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
++option(OMPL_SKIP_RPATH "Don't set RPATH to the OMPL library" OFF)
++if(NOT OMPL_SKIP_RPATH)
++    # Set rpath http://www.paraview.org/Wiki/CMake_RPATH_handling
++    set(CMAKE_SKIP_BUILD_RPATH FALSE)
++    set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
++    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
++    set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
++endif()
+ 
+ # no prefix needed for python modules
+ set(CMAKE_SHARED_MODULE_PREFIX "")
+-- 
+2.9.3
+

--- a/recipes-extended/ompl/ompl_1.1.0.bb
+++ b/recipes-extended/ompl/ompl_1.1.0.bb
@@ -5,10 +5,15 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=923f436234988118e9a042c42a64323c"
 
 DEPENDS = "boost libeigen"
 
-SRC_URI = "https://bitbucket.org/ompl/ompl/downloads/ompl-1.1.0-Source.tar.gz"
+SRC_URI = "https://bitbucket.org/ompl/ompl/downloads/ompl-1.1.0-Source.tar.gz \
+           file://0001-address-gcc6-build-error.patch \
+           file://0002-Add-option-to-skip-setting-RPATH.patch \
+           "
 SRC_URI[md5sum] = "2a72c5add9675e164c8370a710627e93"
 SRC_URI[sha256sum] = "4d141ad3aa322c65ee7ecfa90017a44a8114955316e159b635fae5b5e7db74f8"
 
 S = "${WORKDIR}/ompl-${PV}-Source"
 
 inherit cmake
+
+EXTRA_OECMAKE = "-DOMPL_SKIP_RPATH=ON"

--- a/recipes-ros/household-objects-database-msgs/household-objects-database-msgs_0.1.2.bb
+++ b/recipes-ros/household-objects-database-msgs/household-objects-database-msgs_0.1.2.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "The household_objects_database_msgs package"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "message-generation std-msgs geometry-msgs shape-msgs object-recognition-msgs"
+
+SRC_URI = "https://github.com/ros-interactive-manipulation/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "96cc5baed4d92626044470772745bf58"
+SRC_URI[sha256sum] = "1ab82ef50d580635a7248c83585e641687aa32465c766ebcda5f044778f9ff5b"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin
+
+ROS_SPN = "household_objects_database_msgs"

--- a/recipes-ros/manipulation-msgs/manipulation-msgs_0.2.1.bb
+++ b/recipes-ros/manipulation-msgs/manipulation-msgs_0.2.1.bb
@@ -1,0 +1,16 @@
+DESCRIPTION = "The manipulation_msgs package"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=10;endline=10;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "actionlib-msgs geometry-msgs sensor-msgs shape-msgs household-objects-database-msgs"
+
+SRC_URI = "https://github.com/ros-interactive-manipulation/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
+SRC_URI[md5sum] = "48bb43443982dc6c78afaf2b65a74e67"
+SRC_URI[sha256sum] = "b34fae176367ff727876959e5f40eafeb9a7c158424bc288ae7eb9045e6b3a41"
+
+S = "${WORKDIR}/${ROS_SP}"
+
+inherit catkin
+
+ROS_SPN = "manipulation_msgs"

--- a/recipes-ros/moveit/moveit-kinematics_0.7.9.bb
+++ b/recipes-ros/moveit/moveit-kinematics_0.7.9.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Package for all inverse kinematics solvers in MoveIt!"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "moveit-core moveit-ros-planning"
+
+require moveit.inc
+
+ROS_BPN = "moveit_kinematics"

--- a/recipes-ros/moveit/moveit-planners-ompl_0.7.9.bb
+++ b/recipes-ros/moveit/moveit-planners-ompl_0.7.9.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "MoveIt interface to OMPL"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "moveit-core moveit-ros-planning ompl"
+
+require moveit.inc
+
+ROS_BPN = "moveit_planners/ompl"
+
+FILES_${PN} += "${ros_libdir}/moveit_planners_ompl/*"

--- a/recipes-ros/moveit/moveit-ros-manipulation_0.7.9.bb
+++ b/recipes-ros/moveit/moveit-ros-manipulation_0.7.9.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Components of MoveIt used for manipulation"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "moveit-core moveit-ros-planning moveit-ros-move-group moveit-msgs manipulation-msgs"
+
+require moveit.inc
+
+ROS_BPN = "moveit_ros/manipulation"

--- a/recipes-ros/moveit/moveit-ros-move-group_0.7.9.bb
+++ b/recipes-ros/moveit/moveit-ros-move-group_0.7.9.bb
@@ -1,0 +1,14 @@
+DESCRIPTION = "The move_group node for MoveIt"
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "moveit-core moveit-ros-planning std-srvs"
+
+require moveit.inc
+
+ROS_BPN = "moveit_ros/move_group"
+
+RDEPENDS_${PN} += "moveit-kinematics"
+
+FILES_${PN} += "${ros_libdir}/moveit_ros_move_group/*"

--- a/recipes-ros/moveit/moveit-simple-controller-manager/0001-Fix-conversion-of-shared-ptr-to-bool-for-C-11.patch
+++ b/recipes-ros/moveit/moveit-simple-controller-manager/0001-Fix-conversion-of-shared-ptr-to-bool-for-C-11.patch
@@ -1,0 +1,27 @@
+From 475a3477b2949392130e67182459390960a375c9 Mon Sep 17 00:00:00 2001
+From: Maarten de Vries <maarten@de-vri.es>
+Date: Fri, 20 May 2016 20:08:29 +0200
+Subject: [PATCH] Fix conversion of shared ptr to bool for C++11.
+
+Upstream-Status: Backported [from Kinetic release]
+
+---
+ .../moveit_simple_controller_manager/action_based_controller_handle.h   | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/moveit_simple_controller_manager/action_based_controller_handle.h b/include/moveit_simple_controller_manager/action_based_controller_handle.h
+index f1bec33..e1315fe 100644
+--- a/include/moveit_simple_controller_manager/action_based_controller_handle.h
++++ b/include/moveit_simple_controller_manager/action_based_controller_handle.h
+@@ -86,7 +86,7 @@ public:
+ 
+   bool isConnected() const
+   {
+-    return controller_action_client_;
++    return static_cast<bool>(controller_action_client_);
+   }
+ 
+   virtual bool cancelExecution()
+-- 
+2.9.3
+

--- a/recipes-ros/moveit/moveit-simple-controller-manager_0.7.9.bb
+++ b/recipes-ros/moveit/moveit-simple-controller-manager_0.7.9.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "A generic, simple controller manager plugin for MoveIt."
+SECTION = "devel"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://package.xml;beginline=8;endline=8;md5=d566ef916e9dedc494f5f793a6690ba5"
+
+DEPENDS = "moveit-core actionlib control-msgs pluginlib roscpp"
+
+require moveit.inc
+
+SRC_URI_append = " file://0001-Fix-conversion-of-shared-ptr-to-bool-for-C-11.patch"
+
+ROS_BPN = "moveit_plugins/moveit_simple_controller_manager"

--- a/recipes-ros/packagegroups/packagegroup-ros-world.bb
+++ b/recipes-ros/packagegroups/packagegroup-ros-world.bb
@@ -178,9 +178,14 @@ RDEPENDS_${PN} = "\
     ar-track-alvar \
     ar-track-alvar-msgs \
     moveit-core \
+    moveit-kinematics \
     moveit-msgs \
+    moveit-planners-ompl \
+    moveit-ros-manipulation \
+    moveit-ros-move-group \
     moveit-ros-perception \
     moveit-ros-planning \
+    moveit-simple-controller-manager \
     mavros-msgs \
     cv-camera \
     object-recognition-msgs \


### PR DESCRIPTION
When experimenting with ROS-Industrial and a mechanical arm (uArm Metal) I realized that more packages from MoveIt are needed to plan and execute the arm's trajectories.

Also the PR makes OMPL build again with the latest OE-Core. It's a dependency for trajectory planning too.