### PR TITLE
log4cxx doesn't support http, only https, therefore, the recipe failed

### DIFF
--- a/recipes-devtools/log4cxx/log4cxx_git.bb
+++ b/recipes-devtools/log4cxx/log4cxx_git.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 HOMEPAGE = "http://logging.apache.org/log4cxx/"
 
-SRC_URI = "git://git-wip-us.apache.org/repos/asf/logging-log4cxx.git;protocol=http"
+SRC_URI = "git://git-wip-us.apache.org/repos/asf/logging-log4cxx.git;protocol=https"
 SRCREV = "03c581216a469eb2bc5cabaa686199504d257af0"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Signed-off-by: Sebastien Gemme <sebastien.gemme@canada.ca>