### PR TITLE
sophus: compile on x86-64 arch (resolves #497)

### DIFF
--- a/recipes-extended/sophus/sophus_0.9.1.bb
+++ b/recipes-extended/sophus/sophus_0.9.1.bb
@@ -14,4 +14,4 @@ S = "${WORKDIR}/sophus-${PV}"
 inherit cmake
 
 # CXXFLAGS are needed to compile eigen 3.3.1 headers properly
-CXXFLAGS += "-Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context"
+CXXFLAGS += "-Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-ignored-attributes"


### PR DESCRIPTION
This commit implements Christian Ege's suggestion in the meta-ros issue tracker to make gcc only warn on ignored template attributes.