### PR TITLE
make all recipes build again after recent changes in openembedded-core et al.

### DIFF
--- a/classes/catkin.bbclass
+++ b/classes/catkin.bbclass
@@ -29,6 +29,14 @@ EXTRA_OECMAKE_prepend = "\
 OECMAKE_SOURCEPATH = "${S}"
 OECMAKE_BUILDPATH = "${S}/build"
 
+# Having a command like `find_package(catkin COMPONENTS roscpp)` in a package's CMakeLists.txt
+# leads to adding "-Wl,-rpath=${RECIPE_SYSROOT}${ros_libdir}" option to the cross-linker.
+# However starting from binutils 2.29 the cross-linker prepends this path with the value
+# of --sysroot option thus producing wrong effective path (see https://sourceware.org/ml/binutils/2017-03/msg00161.html)
+# These options help to aleviate the problem.
+OECMAKE_C_LINK_FLAGS += "-Wl,-rpath-link=${RECIPE_SYSROOT}${ros_libdir}"
+OECMAKE_CXX_LINK_FLAGS += "-Wl,-rpath-link=${RECIPE_SYSROOT}${ros_libdir}"
+
 export BUILD_SYS
 export HOST_SYS
 

--- a/recipes-ros/mavlink/mavlink_git.bb
+++ b/recipes-ros/mavlink/mavlink_git.bb
@@ -3,7 +3,7 @@ LICENSE = "LGPLv3"
 LIC_FILES_CHKSUM = "file://COPYING;md5=54ad3cbe91bebcf6b1823970ff1fb97f"
 
 SRC_URI = "git://github.com/mavlink/mavlink-gbp-release.git;branch=release/kinetic/mavlink"
-SRCREV = "${AUTOREV}"
+SRCREV = "release/kinetic/mavlink/2017.8.8-0"
 
 SRC_URI += "file://0001-do-not-require-python2.patch"
 SRC_URI += "file://0002-provide-path-to-find-mavgen_c.patch"

--- a/recipes-ros/openslam-gmapping/openslam-gmapping/0001-make-it-compile-with-glibc-2.26-with-an-explicit-cas.patch
+++ b/recipes-ros/openslam-gmapping/openslam-gmapping/0001-make-it-compile-with-glibc-2.26-with-an-explicit-cas.patch
@@ -1,0 +1,41 @@
+From a48b8169305527f480bfae0f413bd48f818b6bf9 Mon Sep 17 00:00:00 2001
+From: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+Date: Mon, 21 Aug 2017 11:25:33 +0200
+Subject: [PATCH] make it compile with glibc-2.26 with an explicit cast to bool
+
+With glibc-2.26, openslam_gmapping failed to compile with:
+```
+| [...]/gridfastslam/gfsreader.cpp: In member function 'virtual void GMapping::GFSReader::RawOdometryRecord::read(std::istream&)':
+| [...]/gridfastslam/gfsreader.cpp:79:3: error: no match for 'operator==' (operand types are 'std::istream {aka std::basic_istream<char>}' and 'int')
+|    assert(is);
+|    ^
+```
+
+Hence, this commit explicitly casts to bool, so that the assert annotation compiles
+properly again.
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+
+Upstream-Status: Submitted [https://github.com/ros-perception/openslam_gmapping/pull/19]
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ gridfastslam/gfsreader.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gridfastslam/gfsreader.cpp b/gridfastslam/gfsreader.cpp
+index 8b16427..c83f721 100644
+--- a/gridfastslam/gfsreader.cpp
++++ b/gridfastslam/gfsreader.cpp
+@@ -76,7 +76,7 @@ void RawOdometryRecord::read(istream& is){
+   is >> pose.y;
+   is >> pose.theta;
+   time = 0;
+-  assert(is);
++  assert(static_cast<bool>(is));
+     is >> time;
+  
+ }
+-- 
+1.9.1
+

--- a/recipes-ros/openslam-gmapping/openslam-gmapping_0.1.1.bb
+++ b/recipes-ros/openslam-gmapping/openslam-gmapping_0.1.1.bb
@@ -7,6 +7,8 @@ SRC_URI = "https://github.com/ros-perception/${ROS_SPN}/archive/${PV}.tar.gz;dow
 SRC_URI[md5sum] = "da2548abb3d351b199896dc62363ae65"
 SRC_URI[sha256sum] = "b54235b197cfd0bb5ce4689310d1b52af838d4614ac37e5f03be18d53eb39683"
 
+SRC_URI += "file://0001-make-it-compile-with-glibc-2.26-with-an-explicit-cas.patch"
+
 S = "${WORKDIR}/${ROS_SP}"
 
 inherit catkin

--- a/recipes-ros/slam-gmapping/gmapping/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
+++ b/recipes-ros/slam-gmapping/gmapping/0001-make-rostest-in-CMakeLists-optional-ros-rosdistro-30.patch
@@ -3,7 +3,7 @@ From: Lukas Bulwahn <lukas.bulwahn@gmail.com>
 Date: Mon, 3 Apr 2017 17:44:07 +0200
 Subject: [PATCH] make rostest in CMakeLists optional (ros/rosdistro#3010)
 
-Upstream-Status: Submitted [https://github.com/ros-perception/slam_gmapping/pull/48]
+Upstream-Status: Accepted [https://github.com/ros-perception/slam_gmapping/commit/52605268cc37e6e765b2168f41c77d430dde7e51]
 
 Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
 ---

--- a/recipes-ros/velodyne/velodyne-driver_1.2.0.bb
+++ b/recipes-ros/velodyne/velodyne-driver_1.2.0.bb
@@ -6,3 +6,5 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9de
 DEPENDS = "diagnostic-updater libpcap nodelet pluginlib roscpp tf velodyne-msgs"
 
 require velodyne.inc
+
+RDEPENDS_${PN} = "bash"


### PR DESCRIPTION
After updating to binutils 2.29 builds fail with

    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot-native/usr/bin/i586-oe-linux/../../libexec/i586-oe-linux/gcc/i586-oe-linux/7.2.0/ld: warning: libclass_loader.so, needed by /home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so, not found (try using -rpath or -rpath-link)
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot-native/usr/bin/i586-oe-linux/../../libexec/i586-oe-linux/gcc/i586-oe-linux/7.2.0/ld: warning: libroslib.so, needed by /home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so, not found (try using -rpath or -rpath-link)
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::ClassLoader::isLibraryLoaded()'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::MultiLibraryClassLoader::loadLibrary(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::MultiLibraryClassLoader::MultiLibraryClassLoader(bool)'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `ros::package::getPath(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::systemLibrarySuffix[abi:cxx11]()'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::class_loader_private::AbstractMetaObjectBase::isOwnedBy(class_loader::ClassLoader const*)'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::class_loader_private::getFactoryMapForBaseClass(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::MultiLibraryClassLoader::getAllAvailableClassLoaders()'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::ClassLoader::hasUnmanagedInstanceBeenCreated()'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::ClassLoader::unloadLibraryInternal(bool)'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::MultiLibraryClassLoader::unloadLibrary(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::class_loader_private::getPluginBaseToFactoryMapMapMutex()'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::MultiLibraryClassLoader::getRegisteredLibraries[abi:cxx11]()'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `ros::package::getPlugins(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, bool)'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::MultiLibraryClassLoader::~MultiLibraryClassLoader()'
    build/tmp-glibc/work/i586-oe-linux/kdl-parser/1.11.14-r0/recipe-sysroot/opt/ros/indigo/lib/liburdf.so: undefined reference to `class_loader::ClassLoader::loadLibrary()'

because of wrong value of -Wl,-rpath provided to the cross-linker.

This patch makes use of -Wl,-rpath-link option added unconditionally to all
catkin-based builds to aleviate the problem.

NB: The proper fix though should either replace -Wl,-rpath with
-Wl,-rpath-link where it's needed or use correct path to target
libs in -Wl,-rpath.