### PR TITLE
tf2-py: backport python3 fixes

### DIFF
--- a/recipes-ros/geometry2/tf2-py/0001-Use-string-conversion-from-python_compat_h.patch
+++ b/recipes-ros/geometry2/tf2-py/0001-Use-string-conversion-from-python_compat_h.patch
@@ -1,0 +1,26 @@
+From 840caf53b0523b160c2add7e02d3559563826e56 Mon Sep 17 00:00:00 2001
+From: Maarten de Vries <maarten@de-vri.es>
+Date: Sun, 16 Jul 2017 19:46:55 +0200
+Subject: [PATCH 1/2] Use string conversion from python_compat.h.
+
+Upstream-Status: Backport [commit 840caf53b0523b160c2add7e02d3559563826e56]
+---
+ tf2_py/src/tf2_py.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tf2_py/src/tf2_py.cpp b/tf2_py/src/tf2_py.cpp
+index 3d680d7..edd38fe 100644
+--- a/tf2_py/src/tf2_py.cpp
++++ b/tf2_py/src/tf2_py.cpp
+@@ -536,7 +536,7 @@ static PyObject *_allFramesAsDot(PyObject *self, PyObject *args, PyObject *kw)
+   ros::Time time;
+   if (!PyArg_ParseTupleAndKeywords(args, kw, "|O&", (char**)keywords, rostime_converter, &time))
+     return NULL;
+-  return PyString_FromString(bc->_allFramesAsDot(time.toSec()).c_str());
++  return stringToPython(bc->_allFramesAsDot(time.toSec()));
+ }
+ 
+ 
+-- 
+2.1.4
+

--- a/recipes-ros/geometry2/tf2-py/0002-fix-python3-import-error.patch
+++ b/recipes-ros/geometry2/tf2-py/0002-fix-python3-import-error.patch
@@ -1,0 +1,70 @@
+From 552c5c239a9ac21f99c99c41d6fe8739072a87de Mon Sep 17 00:00:00 2001
+From: randoms <randoms@bwbot.org>
+Date: Wed, 9 Aug 2017 11:16:07 +0800
+Subject: [PATCH 2/2] fix python3 import error
+
+Upstream-Status: Backport [commit 552c5c239a9ac21f99c99c41d6fe8739072a87de]
+
+---
+ tf2_py/src/tf2_py.cpp           |  2 +-
+ tf2_py/src/tf2_py/__init__.py   |  5 +++--
+ tf2_ros/src/tf2_ros/__init__.py | 15 ++++++++-------
+ 3 files changed, 12 insertions(+), 10 deletions(-)
+
+diff --git a/tf2_py/src/tf2_py.cpp b/tf2_py/src/tf2_py.cpp
+index edd38fe..279a2d2 100644
+--- a/tf2_py/src/tf2_py.cpp
++++ b/tf2_py/src/tf2_py.cpp
+@@ -632,7 +632,7 @@ struct PyModuleDef tf_module = {
+   module_methods         // methods
+ };
+ 
+-PyMODINIT_FUNC PyInit_tf2()
++PyMODINIT_FUNC PyInit__tf2()
+ {
+   if (!staticInit())
+     return NULL;
+diff --git a/tf2_py/src/tf2_py/__init__.py b/tf2_py/src/tf2_py/__init__.py
+index ccade4e..5a38341 100644
+--- a/tf2_py/src/tf2_py/__init__.py
++++ b/tf2_py/src/tf2_py/__init__.py
+@@ -31,7 +31,8 @@
+ #*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ #*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ #*  POSSIBILITY OF SUCH DAMAGE.
+-#* 
++#*
+ #* Author: Eitan Marder-Eppstein
+ #***********************************************************
+-from _tf2 import *
++from __future__ import absolute_import
++from ._tf2 import *
+diff --git a/tf2_ros/src/tf2_ros/__init__.py b/tf2_ros/src/tf2_ros/__init__.py
+index b3df91b..af5642c 100644
+--- a/tf2_ros/src/tf2_ros/__init__.py
++++ b/tf2_ros/src/tf2_ros/__init__.py
+@@ -31,13 +31,14 @@
+ #*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ #*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ #*  POSSIBILITY OF SUCH DAMAGE.
+-#* 
++#*
+ #* Author: Eitan Marder-Eppstein
+ #***********************************************************
++from __future__ import absolute_import
+ from tf2_py import *
+-from buffer_interface import *
+-from buffer import *
+-from buffer_client import *
+-from transform_listener import *
+-from transform_broadcaster import *
+-from static_transform_broadcaster import *
++from .buffer_interface import *
++from .buffer import *
++from .buffer_client import *
++from .transform_listener import *
++from .transform_broadcaster import *
++from .static_transform_broadcaster import *
+-- 
+2.1.4
+

--- a/recipes-ros/geometry2/tf2-py_0.5.16.bb
+++ b/recipes-ros/geometry2/tf2-py_0.5.16.bb
@@ -10,3 +10,8 @@ EXTRA_OECMAKE += "\
     "
 
 require geometry2.inc
+
+SRC_URI += " \
+    file://0001-Use-string-conversion-from-python_compat_h.patch;patchdir=${WORKDIR}/${ROS_SP} \
+    file://0002-fix-python3-import-error.patch;patchdir=${WORKDIR}/${ROS_SP} \
+"


### PR DESCRIPTION
A change before the v0.5.16 release broke python3 compatibility
and that triggers a build failure when ROS_USE_PYTHON3 = "yes".

To fix the build, backport two python3 related patches on top
of v0.5.16.

Signed-off-by: Mikko Ylinen <mikko.ylinen@linux.intel.com>