### PR TITLE
tf2: ship tf2-msgs with tf2

### DIFF
--- a/recipes-ros/geometry2/tf2_0.5.16.bb
+++ b/recipes-ros/geometry2/tf2_0.5.16.bb
@@ -6,4 +6,6 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=16;endline=16;md5=d566ef916e9de
 
 DEPENDS = "tf2-msgs geometry-msgs console-bridge rospy"
 
+RDEPENDS_${PN} += "tf2-msgs geometry-msgs console-bridge rostime"
+
 require geometry2.inc


### PR DESCRIPTION
## What I did
I added `tf2-msgs` as a run dependency to `tf2`.

## Why
Since tf2-msgs was not a run dependency, it was not shipped when only using `tf2`, creating runtime issues. I checked the manifest, it is now included properly

## Versions I use
meta-ros@88ce154 (12th June 2017)
poky 2.2