### PR TITLE
smach: update dependencies and run dependencies

### DIFF
--- a/recipes-ros/executive-smach/smach-msgs_2.0.1.bb
+++ b/recipes-ros/executive-smach/smach-msgs_2.0.1.bb
@@ -5,4 +5,6 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9de
 
 DEPENDS = "message-generation std-msgs roscpp-serialization"
 
+RDEPENDS_${PN} = "message-runtime"
+
 require executive-smach.inc

--- a/recipes-ros/executive-smach/smach-ros_2.0.1.bb
+++ b/recipes-ros/executive-smach/smach-ros_2.0.1.bb
@@ -3,4 +3,8 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=17;endline=17;md5=d566ef916e9dedc494f5f793a6690ba5"
 
+DEPENDS = "rostest rospy rostopic std-msgs std-srvs actionlib actionlib-msgs"
+
+RDEPENDS_${PN} = "smach smach-msgs"
+
 require executive-smach.inc


### PR DESCRIPTION
## What I did
Update dependencies of smach packages according to [source](https://github.com/ros/executive_smach)

## Why I did it
Appending `smach-ros` in an image was not adding automatically `smach-msgs`