### PR TITLE
wxwidgets: adjust to openembedded-core@0391fcad (resolves #578)

### DIFF
--- a/recipes-extended/wxwidgets/wxwidgets_2.9.5.bb
+++ b/recipes-extended/wxwidgets/wxwidgets_2.9.5.bb
@@ -24,7 +24,7 @@ EXTRA_OECONF = "  --with-opengl \
                  --disable-rpath \
                "
 
-CXXFLAGS := "${@oe_filter_out('-fvisibility-inlines-hidden', '${CXXFLAGS}', d)}"
+CXXFLAGS := "${@oe.utils.str_filter_out('-fvisibility-inlines-hidden', '${CXXFLAGS}', d)}"
 CXXFLAGS += "-std=gnu++11"
 
 # Broken autotools :/


### PR DESCRIPTION
Commit openembedded/openembedded-core@0391fca ("classes/utils: remove compatibility functions") forces us to update to the proper oe.utils functions.