### PR TITLE
adjust to update of boost 1.67

### DIFF
--- a/recipes-devtools/yaml-cpp/yaml-cpp_0.6.2.bb
+++ b/recipes-devtools/yaml-cpp/yaml-cpp_0.6.2.bb
@@ -4,16 +4,14 @@ SECTION = "libs"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=6a8aaf0595c2efc1a9c2e0913e9c1a2c"
 
-DEPENDS = "boost"
-
 PR = "r0"
 
 S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/jbeder/${PN}.git;branch=master;protocol=git"
-SRCREV = "b57efe94e7d445713c29f863adb8c23438eaa217"
+SRCREV = "562aefc114938e388457e6a531ed7b54d9dc1b62"
 
 
-EXTRA_OECMAKE = "-DBUILD_SHARED_LIBS=ON"
+EXTRA_OECMAKE = "-DBUILD_SHARED_LIBS=ON -DYAML_CPP_BUILD_TESTS=OFF"
 
 inherit cmake

--- a/recipes-ros/actionlib/actionlib/0001-Change-boost-posix_time-milliseconds-init-to-int64_t.patch
+++ b/recipes-ros/actionlib/actionlib/0001-Change-boost-posix_time-milliseconds-init-to-int64_t.patch
@@ -1,0 +1,87 @@
+From 677e952fcbfe49e6e4c5b835357f88740f49c6ff Mon Sep 17 00:00:00 2001
+From: Tobias Fischer <t.fischer@imperial.ac.uk>
+Date: Sun, 29 Apr 2018 23:56:16 +0100
+Subject: [PATCH] Change boost::posix_time::milliseconds init to int64_t (#105)
+
+* Change boost::posix_time::milliseconds init to uint64_t
+
+Fixes #104
+
+* Update simple_action_server_imp.h
+
+* Update destruction_guard.h
+
+* Update simple_action_client.h
+
+* use int64_t
+
+Upstream-Status: Accepted [https://github.com/ros/actionlib/commit/677e952fcbfe49e6e4c5b835357f88740f49c6ff]
+
+This patch has been generated with:
+  `git format-patch -1 677e952fcbfe49e6e4c5b835357f88740f49c6ff`
+in the actionlib repository.
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ include/actionlib/client/simple_action_client.h     | 3 ++-
+ include/actionlib/destruction_guard.h               | 2 +-
+ include/actionlib/server/simple_action_server_imp.h | 2 +-
+ src/connection_monitor.cpp                          | 2 +-
+ 4 files changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/include/actionlib/client/simple_action_client.h b/include/actionlib/client/simple_action_client.h
+index f86ac99..eda76aa 100644
+--- a/include/actionlib/client/simple_action_client.h
++++ b/include/actionlib/client/simple_action_client.h
+@@ -601,7 +601,8 @@ bool SimpleActionClient<ActionSpec>::waitForResult(const ros::Duration & timeout
+       time_left = loop_period;
+     }
+ 
+-    done_condition_.timed_wait(lock, boost::posix_time::milliseconds(time_left.toSec() * 1000.0f));
++    done_condition_.timed_wait(lock,
++      boost::posix_time::milliseconds(static_cast<int64_t>(time_left.toSec() * 1000.0f)));
+   }
+ 
+   return cur_simple_state_ == SimpleGoalState::DONE;
+diff --git a/include/actionlib/destruction_guard.h b/include/actionlib/destruction_guard.h
+index 196a0a7..1aaa776 100644
+--- a/include/actionlib/destruction_guard.h
++++ b/include/actionlib/destruction_guard.h
+@@ -59,7 +59,7 @@ public:
+     boost::mutex::scoped_lock lock(mutex_);
+     destructing_ = true;
+     while (use_count_ > 0) {
+-      count_condition_.timed_wait(lock, boost::posix_time::milliseconds(1000.0f));
++      count_condition_.timed_wait(lock, boost::posix_time::milliseconds(1000));
+     }
+   }
+ 
+diff --git a/include/actionlib/server/simple_action_server_imp.h b/include/actionlib/server/simple_action_server_imp.h
+index 3975ec6..367bc22 100644
+--- a/include/actionlib/server/simple_action_server_imp.h
++++ b/include/actionlib/server/simple_action_server_imp.h
+@@ -394,7 +394,7 @@ void SimpleActionServer<ActionSpec>::executeLoop()
+       }
+     } else {
+       execute_condition_.timed_wait(lock,
+-        boost::posix_time::milliseconds(loop_duration.toSec() * 1000.0f));
++        boost::posix_time::milliseconds(static_cast<int64_t>(loop_duration.toSec() * 1000.0f)));
+     }
+   }
+ }
+diff --git a/src/connection_monitor.cpp b/src/connection_monitor.cpp
+index 19fe21a..43184c3 100644
+--- a/src/connection_monitor.cpp
++++ b/src/connection_monitor.cpp
+@@ -275,7 +275,7 @@ bool actionlib::ConnectionMonitor::waitForActionServerToStart(const ros::Duratio
+     }
+ 
+     check_connection_condition_.timed_wait(lock,
+-      boost::posix_time::milliseconds(time_left.toSec() * 1000.0f));
++      boost::posix_time::milliseconds(static_cast<int64_t>(time_left.toSec() * 1000.0f)));
+   }
+ 
+   return isServerConnected();
+-- 
+2.7.4
+

--- a/recipes-ros/actionlib/actionlib_1.11.13.bb
+++ b/recipes-ros/actionlib/actionlib_1.11.13.bb
@@ -11,3 +11,5 @@ SRC_URI[md5sum] = "2a607a3455f5ea5908254bd65c9230c9"
 SRC_URI[sha256sum] = "df635716bd65298aa443f86fb3578988af04f404c4a94ebc99ef61ac4c869e46"
 
 inherit catkin
+
+SRC_URI += "file://0001-Change-boost-posix_time-milliseconds-init-to-int64_t.patch"

--- a/recipes-ros/bond-core/bond-core.inc
+++ b/recipes-ros/bond-core/bond-core.inc
@@ -7,3 +7,5 @@ S = "${WORKDIR}/${ROS_SP}/${ROS_BPN}"
 inherit catkin
 
 ROS_SPN = "bond_core"
+
+SRC_URI += "file://0001-Argument-to-Boost-Milliseconds-must-be-integral-in-B.patch;patchdir=.."

--- a/recipes-ros/bond-core/files/0001-Argument-to-Boost-Milliseconds-must-be-integral-in-B.patch
+++ b/recipes-ros/bond-core/files/0001-Argument-to-Boost-Milliseconds-must-be-integral-in-B.patch
@@ -1,0 +1,50 @@
+From 1240bce50ca1538cdad07dc472d31797257e0851 Mon Sep 17 00:00:00 2001
+From: Paul-Edouard Sarlin <Skydes@users.noreply.github.com>
+Date: Sun, 29 Apr 2018 22:40:15 +0200
+Subject: [PATCH] Argument to Boost Milliseconds must be integral in Boost >=
+ 1.67 (#37)
+
+* Argument to Boost milliseconds  must be integral
+
+* Fix style
+
+* More consistent type
+
+Upstream-Status: Accepted [https://github.com/ros/bond_core/commit/1240bce50ca1538cdad07dc472d31797257e0851]
+
+This patch has been generated with:
+  `git format-patch -1 1240bce50ca1538cdad07dc472d31797257e0851`
+in the bond_core repository.
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ bondcpp/src/bond.cpp | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/bondcpp/src/bond.cpp b/bondcpp/src/bond.cpp
+index 8872d61..58e7901 100644
+--- a/bondcpp/src/bond.cpp
++++ b/bondcpp/src/bond.cpp
+@@ -218,7 +218,8 @@ bool Bond::waitUntilFormed(ros::WallDuration timeout)
+       break;  // The deadline has expired
+     }
+ 
+-    condition_.timed_wait(mutex_, boost::posix_time::milliseconds(wait_time.toSec() * 1000.0f));
++    condition_.timed_wait(mutex_, boost::posix_time::milliseconds(
++      static_cast<int64_t>(wait_time.toSec() * 1000.0f)));
+   }
+   return sm_.getState().getId() != SM::WaitingForSister.getId();
+ }
+@@ -246,7 +247,8 @@ bool Bond::waitUntilBroken(ros::WallDuration timeout)
+       break;  // The deadline has expired
+     }
+ 
+-    condition_.timed_wait(mutex_, boost::posix_time::milliseconds(wait_time.toSec() * 1000.0f));
++    condition_.timed_wait(mutex_, boost::posix_time::milliseconds(
++      static_cast<int64_t>(wait_time.toSec() * 1000.0f)));
+   }
+   return sm_.getState().getId() == SM::Dead.getId();
+ }
+-- 
+2.7.4
+

--- a/recipes-ros/ros-comm/roscpp/0001-make-implicit-cast-explicit.patch
+++ b/recipes-ros/ros-comm/roscpp/0001-make-implicit-cast-explicit.patch
@@ -1,3 +1,9 @@
+Upstream-Status: Inappropriate [upstream source code changed]
+
+The current upstream source code (in melodic-devel) changed, and for the indigo
+and kinetic releases, it is irrelevant to be submitted back and applied because
+boost will not be updated to 1.67 in the supported Debian/Ubuntu distributions.
+
 diff --git a/clients/roscpp/src/libros/callback_queue.cpp b/clients/roscpp/src/libros/callback_queue.cpp
 index cd2f4f8..fa600d5 100644
 --- a/clients/roscpp/src/libros/callback_queue.cpp

--- a/recipes-ros/roscpp-core/files/0001-argument-to-boost-microseconds-must-be-integral.patch
+++ b/recipes-ros/roscpp-core/files/0001-argument-to-boost-microseconds-must-be-integral.patch
@@ -1,3 +1,24 @@
+From e5de3c20eb178683c78e225d00bf0f47c48895a5 Mon Sep 17 00:00:00 2001
+From: Lukas Solanka <lsolanka@gmail.com>
+Date: Tue, 17 Apr 2018 22:59:48 +0100
+Subject: [PATCH] argument to boost microseconds must be integral
+
+With Boost >= 1.67 compilation fails because now it requires the
+constructor argument to be integral.
+
+Upstream-Status: Submitted [https://github.com/ros/roscpp_core/pull/79]
+
+This patch has been generated with:
+  `git pull https://github.com/lsolanka/roscpp_core.git pr.microseconds-integer && \
+  git format-patch -1 e5de3c20eb178683c78e225d00bf0f47c48895a5`
+in the roscpp_core repository.
+
+Signed-off-by: Lukas Bulwahn <lukas.bulwahn@gmail.com>
+---
+ rostime/include/ros/impl/duration.h | 2 +-
+ rostime/include/ros/impl/time.h     | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
 diff --git a/rostime/include/ros/impl/duration.h b/rostime/include/ros/impl/duration.h
 index 2ca2f5b..7ebd202 100644
 --- a/rostime/include/ros/impl/duration.h
@@ -24,3 +45,6 @@ index ec991e6..61b686c 100644
  #endif
    }
  
+-- 
+2.7.4
+

--- a/recipes-ros/roscpp-core/rostime_0.5.8.bb
+++ b/recipes-ros/roscpp-core/rostime_0.5.8.bb
@@ -7,4 +7,4 @@ DEPENDS = "boost cpp-common"
 
 require roscpp-core.inc
 
-SRC_URI += "file://0001-remove-implicit-cast.patch;striplevel=2"
+SRC_URI += "file://0001-argument-to-boost-microseconds-must-be-integral.patch;striplevel=2"


### PR DESCRIPTION
`bitbake core-image-ros-world` ran successfully with `ROS_USE_PYTHON3 = "no"` on this build configuration:
```
Build Configuration:
BB_VERSION           = "1.37.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "ubuntu-16.04"
TARGET_SYS           = "i586-oe-linux"
MACHINE              = "qemux86"
DISTRO               = "nodistro"
DISTRO_VERSION       = "nodistro.0"
TUNE_FEATURES        = "m32 i586"
TARGET_FPU           = ""
meta                 = "master:9611485bba03ef77ff31121e3b1da7cd57990c3e"
meta-oe              
meta-python          
meta-multimedia      = "master:a19aa29f7fa336cd075b72c496fe1102e6e5422b"
meta-ros             = "boost-1.67-update:5f4adb97ce3b6a4a2741357d777bc1f64ec8c7ab"
```

I did test it with `USE_ROS_PYTHON3 = "yes"`, but as the boost recipe has not been adjusted yet, `bitbake core-image-ros-world` fails with:
```
Summary: 2 tasks failed:
  /home/lukas/repositories/github.com/bmwcarit/meta-ros/recipes-ros/vision-opencv/cv-bridge_1.11.16.bb:do_configure
  /home/lukas/repositories/github.com/bmwcarit/meta-ros/recipes-ros/image-common/camera-calibration-parsers_1.11.13.bb:do_configure
```