### PR TITLE
dynamic-reconfigure properly depends on ${PYTHON_PN}-rospkg

### DIFF
--- a/recipes-ros/control-toolbox/control-toolbox_1.13.3.bb
+++ b/recipes-ros/control-toolbox/control-toolbox_1.13.3.bb
@@ -4,7 +4,7 @@ LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=d566ef916e9dedc494f5f793a6690ba5"
 
 DEPENDS = "rosconsole tf roscpp angles message-generation dynamic-reconfigure libtinyxml \
-    realtime-tools message-filters ${PYTHON_PN}-rospkg"
+    realtime-tools message-filters"
 
 SRC_URI = "https://github.com/ros-controls/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "3df0a768373bdf0b6297a4246ef4885b"

--- a/recipes-ros/depthimage-to-laserscan/depthimage-to-laserscan_1.0.7.bb
+++ b/recipes-ros/depthimage-to-laserscan/depthimage-to-laserscan_1.0.7.bb
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=7;endline=7;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "roscpp sensor-msgs nodelet image-transport image-geometry dynamic-reconfigure ${PYTHON_PN}-rospkg"
+DEPENDS = "roscpp sensor-msgs nodelet image-transport image-geometry dynamic-reconfigure"
 
 SRC_URI = "https://github.com/ros-perception/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz \
            file://0001-Add-missing-std-namespace-prefixes.patch \

--- a/recipes-ros/dynamic-reconfigure/dynamic-reconfigure_1.5.49.bb
+++ b/recipes-ros/dynamic-reconfigure/dynamic-reconfigure_1.5.49.bb
@@ -4,7 +4,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=11;endline=11;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "roscpp std-msgs roslib"
+DEPENDS = "roscpp std-msgs roslib ${PYTHON_PN}-rospkg"
 
 SRC_URI = "https://github.com/ros/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "c8205d14f3084e1dae677bc0812bb769"

--- a/recipes-ros/image-pipeline/image-proc_1.12.23.bb
+++ b/recipes-ros/image-pipeline/image-proc_1.12.23.bb
@@ -5,6 +5,6 @@ LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc
 
 DEPENDS = "boost camera-calibration-parsers cv-bridge dynamic-reconfigure \
   image-geometry image-transport nodelet nodelet-topic-tools opencv roscpp \
-  sensor-msgs ${PYTHON_PN}-rospkg"
+  sensor-msgs"
 
 require image-pipeline.inc

--- a/recipes-ros/image-pipeline/image-publisher_1.12.23.bb
+++ b/recipes-ros/image-pipeline/image-publisher_1.12.23.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "camera-info-manager cv-bridge dynamic-reconfigure image-transport nodelet roscpp sensor-msgs ${PYTHON_PN}-rospkg"
+DEPENDS = "camera-info-manager cv-bridge dynamic-reconfigure image-transport nodelet roscpp sensor-msgs"
 
 require image-pipeline.inc

--- a/recipes-ros/image-pipeline/image-rotate_1.12.23.bb
+++ b/recipes-ros/image-pipeline/image-rotate_1.12.23.bb
@@ -4,6 +4,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=26;endline=26;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cmake-modules cv-bridge dynamic-reconfigure eigen-conversions image-transport nodelet opencv roscpp tf2 tf2-geometry-msgs tf2-ros ${PYTHON_PN}-rospkg"
+DEPENDS = "cmake-modules cv-bridge dynamic-reconfigure eigen-conversions image-transport nodelet opencv roscpp tf2 tf2-geometry-msgs tf2-ros"
 
 require image-pipeline.inc

--- a/recipes-ros/image-transport-plugins/compressed-depth-image-transport_1.9.5.bb
+++ b/recipes-ros/image-transport-plugins/compressed-depth-image-transport_1.9.5.bb
@@ -4,6 +4,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf ${PYTHON_PN}-rospkg"
+DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf"
 
 require image-transport-plugins.inc

--- a/recipes-ros/image-transport-plugins/compressed-image-transport_1.9.5.bb
+++ b/recipes-ros/image-transport-plugins/compressed-image-transport_1.9.5.bb
@@ -4,6 +4,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf ${PYTHON_PN}-rospkg"
+DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf"
 
 require image-transport-plugins.inc

--- a/recipes-ros/image-transport-plugins/theora-image-transport_1.9.5.bb
+++ b/recipes-ros/image-transport-plugins/theora-image-transport_1.9.5.bb
@@ -4,6 +4,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf rosbag ${PYTHON_PN}-rospkg"
+DEPENDS = "cv-bridge dynamic-reconfigure image-transport tf rosbag libtheora"
 
 require image-transport-plugins.inc

--- a/recipes-ros/moveit/moveit-ros-planning_0.7.13.bb
+++ b/recipes-ros/moveit/moveit-ros-planning_0.7.13.bb
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=13;endline=13;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "moveit-core moveit-ros-perception dynamic-reconfigure ${PYTHON_PN}-rospkg libtinyxml tf-conversions"
+DEPENDS = "moveit-core moveit-ros-perception dynamic-reconfigure libtinyxml tf-conversions"
 
 require moveit.inc
 

--- a/recipes-ros/navigation/amcl_1.12.16.bb
+++ b/recipes-ros/navigation/amcl_1.12.16.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "LGPL-2.1+"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=22;endline=22;md5=58d727014cda5ed405b7fb52666a1f97"
 
-DEPENDS = "dynamic-reconfigure message-filters nav-msgs rosbag roscpp std-srvs tf ${PYTHON_PN}-rospkg"
+DEPENDS = "dynamic-reconfigure message-filters nav-msgs rosbag roscpp std-srvs tf"
 
 require navigation.inc

--- a/recipes-ros/razor-imu-9dof/razor-imu-9dof_1.2.0.bb
+++ b/recipes-ros/razor-imu-9dof/razor-imu-9dof_1.2.0.bb
@@ -7,7 +7,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=15;endline=15;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "dynamic-reconfigure ${PYTHON_PN}-rospkg"
+DEPENDS = "dynamic-reconfigure"
 
 SRC_URI = "https://github.com/KristofRobot/${ROS_SPN}/archive/${PV}.tar.gz;downloadfilename=${ROS_SP}.tar.gz"
 SRC_URI[md5sum] = "1d036536b614e4e9841c970150692e46"

--- a/recipes-ros/velodyne/velodyne-driver_1.3.0.bb
+++ b/recipes-ros/velodyne/velodyne-driver_1.3.0.bb
@@ -3,7 +3,7 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=14;endline=14;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "diagnostic-updater dynamic-reconfigure ${PYTHON_PN}-rospkg libpcap nodelet pluginlib roscpp tf velodyne-msgs"
+DEPENDS = "diagnostic-updater dynamic-reconfigure libpcap nodelet pluginlib roscpp tf velodyne-msgs"
 
 require velodyne.inc
 

--- a/recipes-ros/yujin-ocs/yocs-cmd-vel-mux_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-cmd-vel-mux_0.6.4.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=12;endline=12;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "roscpp nodelet dynamic-reconfigure pluginlib geometry-msgs yaml-cpp ${PYTHON_PN}-rospkg"
+DEPENDS = "roscpp nodelet dynamic-reconfigure pluginlib geometry-msgs yaml-cpp"
 
 require yujin-ocs.inc

--- a/recipes-ros/yujin-ocs/yocs-velocity-smoother_0.6.4.bb
+++ b/recipes-ros/yujin-ocs/yocs-velocity-smoother_0.6.4.bb
@@ -3,6 +3,6 @@ SECTION = "devel"
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=d566ef916e9dedc494f5f793a6690ba5"
 
-DEPENDS = "roscpp pluginlib nodelet geometry-msgs nav-msgs ecl-threads dynamic-reconfigure ${PYTHON_PN}-rospkg"
+DEPENDS = "roscpp pluginlib nodelet geometry-msgs nav-msgs ecl-threads dynamic-reconfigure"
 
 require yujin-ocs.inc


### PR DESCRIPTION
Added ${PYTHON_PN}-rospkg to DEPENDS. Packages with dreconf will fail to build
if they not have rospkg in its depends.
Fixes #593 