### PR TITLE
[thud] libyaml-vendor: use platform libyaml to unblock rpm packaging

### DIFF
--- a/meta-ros2-dashing/conf/ros-distro/include/dashing/ros-distro-preferred-providers.inc
+++ b/meta-ros2-dashing/conf/ros-distro/include/dashing/ros-distro-preferred-providers.inc
@@ -1,10 +1,6 @@
 # dashing/ros-distro-preferred-providers.inc
 #
-# Copyright (c) 2019 LG Electronics, Inc.
+# Copyright (c) 2019-2020 LG Electronics, Inc.
 
 # Set PREFERRED_PROVIDER_<PN> here for non-platform packages and to override those set in
 # ros-distro-platform-preferred-providers.inc .
-
-PREFERRED_PROVIDER_libyaml = "libyaml-vendor"
-PREFERRED_PROVIDER_libyaml-dev = "libyaml-vendor-dev"
-PREFERRED_PROVIDER_libyaml-dbg = "libyaml-vendor-dbg"

--- a/meta-ros2-dashing/conf/ros-distro/include/dashing/ros-distro-recipe-blacklist.inc
+++ b/meta-ros2-dashing/conf/ros-distro/include/dashing/ros-distro-recipe-blacklist.inc
@@ -11,7 +11,6 @@
 # (none)
 
 # Others
-PNBLACKLIST[libyaml] ?= "Provided by libyaml-vendor"
 
 PNBLACKLIST[ament-clang-format-native] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'clang', 'clang-format: depends on clang-format', '', d)}"
 PNBLACKLIST[ament-clang-format] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'clang', 'clang-format: depends on clang-format', '', d)}"

--- a/meta-ros2-dashing/recipes-bbappends/libyaml-vendor/libyaml-vendor/0001-CMakeLists.txt-use-platform-libyaml-when-available-i.patch
+++ b/meta-ros2-dashing/recipes-bbappends/libyaml-vendor/libyaml-vendor/0001-CMakeLists.txt-use-platform-libyaml-when-available-i.patch
@@ -1,0 +1,33 @@
+From 1240f9246fb4ffdab1441716fbd35f4eab126f74 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Thu, 9 Jul 2020 01:34:26 -0700
+Subject: [PATCH] CMakeLists.txt: use platform libyaml when available instead
+ of ExternalProject
+
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ CMakeLists.txt | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 99e6826..3ce4e2c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,7 +64,16 @@ macro(build_libyaml)
+   )
+ endmacro()
+ 
+-build_libyaml()
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(YAML REQUIRED yaml-0.1)
++
++if(YAML_FOUND)
++  message(STATUS "Found yaml ${YAML_VERSION}")
++else()
++  message(FATAL_ERROR "yaml not found -- missing from DEPENDS?")
++  # eventually we can build one with ExternalProjectAdd
++  # build_libyaml()
++endif()
+ 
+ ament_export_libraries(yaml)
+ 

--- a/meta-ros2-dashing/recipes-bbappends/libyaml-vendor/libyaml-vendor_%.bbappend
+++ b/meta-ros2-dashing/recipes-bbappends/libyaml-vendor/libyaml-vendor_%.bbappend
@@ -1,16 +1,14 @@
 # Copyright (c) 2019-2020 LG Electronics, Inc.
 
-FILES_${PN}-dev_prepend = "${prefix}/cmake "
-SYSROOT_DIRS_append = " ${prefix}/cmake"
+DEPENDS += "libyaml"
 
-PROVIDES += "libyaml"
-RPROVIDES_${PN} += "libyaml"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://0001-CMakeLists.txt-fetch-libyaml-with-bitbake-fetcher.patch \
+    file://0001-CMakeLists.txt-use-platform-libyaml-when-available-i.patch \
+"
 
 # Instead of fetching
 # https://github.com/yaml/libyaml/archive/10c907871f1ccd779c7fccf6b81a62762b5c4e7b.zip
 # during do_compile
-FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
-SRC_URI += "file://0001-CMakeLists.txt-fetch-libyaml-with-bitbake-fetcher.patch \
-    git://github.com/yaml/libyaml.git;protocol=https;branch=release-0.1.8;name=libyaml;destsuffix=git/libyaml-upstream \
-"
-SRCREV_libyaml = "10c907871f1ccd779c7fccf6b81a62762b5c4e7b"
+# git://github.com/yaml/libyaml.git;protocol=https;branch=release-0.1.8;name=libyaml;destsuffix=git/libyaml-upstream \
+# SRCREV_libyaml = "10c907871f1ccd779c7fccf6b81a62762b5c4e7b"

--- a/meta-ros2-dashing/recipes-bbappends/rcl/rcl-yaml-param-parser/0001-CMakeLists.txt-use-pkg-config-to-find-yaml.patch
+++ b/meta-ros2-dashing/recipes-bbappends/rcl/rcl-yaml-param-parser/0001-CMakeLists.txt-use-pkg-config-to-find-yaml.patch
@@ -1,0 +1,63 @@
+From b3ec28865712505c64203b62010718e22f4a8f40 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Thu, 9 Jul 2020 01:44:31 -0700
+Subject: [PATCH] CMakeLists.txt: use pkg-config to find yaml
+
+* yaml-0.1.8 built with CMake in libyaml-vendor ExternalProject_add call
+  provides yamlConfig, but platform yaml-0.2* from oe-core built with
+  autotools provides only pkg-config file yaml-1.0.pc, I've tried to change
+  oe-core recipe from autotools to cmake, but it seems to be broken in
+  upstream libyaml as shown bellow, we should continue to use upstream preferred autotools
+  https://github.com/yaml/libyaml/issues/141
+  https://github.com/yaml/libyaml/issues/138
+
+| CMake Error: File /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/cmake/config.h.in does not exist.
+| CMake Error at CMakeLists.txt:51 (configure_file):
+|   configure_file Problem configuring file
+|
+|
+| CMake Error at CMakeLists.txt:103 (add_subdirectory):
+|   The source directory
+|
+|     /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/tests
+|
+|   does not contain a CMakeLists.txt file.
+|
+|
+| CMake Error: File /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/yamlConfig.cmake.in does not exist.
+| CMake Error at /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/recipe-sysroot-native/usr/share/cmake-3.17/Modules/CMakePackageConfigHelpers.cmake:330 (configure_file):
+|   configure_file Problem configuring file
+| Call Stack (most recent call first):
+|   CMakeLists.txt:114 (configure_package_config_file)
+|
+|
+| CMake Error: File /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/yamlConfig.cmake.in does not exist.
+| CMake Error at /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/recipe-sysroot-native/usr/share/cmake-3.17/Modules/CMakePackageConfigHelpers.cmake:330 (configure_file):
+|   configure_file Problem configuring file
+| Call Stack (most recent call first):
+|   CMakeLists.txt:130 (configure_package_config_file)
+|
+|
+| -- Configuring incomplete, errors occurred!
+| See also "/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/build/CMakeFiles/CMakeOutput.log".
+| WARNING: exit code 1 from a shell command.
+
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 95143c8..02319dc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,7 +6,8 @@ find_package(ament_cmake_ros REQUIRED)
+ find_package(rcutils REQUIRED)
+ find_package(rcl REQUIRED)
+ find_package(libyaml_vendor REQUIRED)
+-find_package(yaml REQUIRED)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(yaml REQUIRED yaml-0.1)
+ 
+ # Default to C++14
+ if(NOT CMAKE_CXX_STANDARD)

--- a/meta-ros2-dashing/recipes-bbappends/rcl/rcl-yaml-param-parser_0.7.8-1.bbappend
+++ b/meta-ros2-dashing/recipes-bbappends/rcl/rcl-yaml-param-parser_0.7.8-1.bbappend
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 LG Electronics, Inc.
+
+DEPENDS += "libyaml"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://0001-CMakeLists.txt-use-pkg-config-to-find-yaml.patch"

--- a/meta-ros2-eloquent/conf/ros-distro/include/eloquent/ros-distro-preferred-providers.inc
+++ b/meta-ros2-eloquent/conf/ros-distro/include/eloquent/ros-distro-preferred-providers.inc
@@ -1,10 +1,6 @@
 # eloquent/ros-distro-preferred-providers.inc
 #
-# Copyright (c) 2019 LG Electronics, Inc.
+# Copyright (c) 2019-2020 LG Electronics, Inc.
 
 # Set PREFERRED_PROVIDER_<PN> here for non-platform packages and to override those set in
 # ros-distro-platform-preferred-providers.inc .
-
-PREFERRED_PROVIDER_libyaml = "libyaml-vendor"
-PREFERRED_PROVIDER_libyaml-dev = "libyaml-vendor-dev"
-PREFERRED_PROVIDER_libyaml-dbg = "libyaml-vendor-dbg"

--- a/meta-ros2-eloquent/conf/ros-distro/include/eloquent/ros-distro-recipe-blacklist.inc
+++ b/meta-ros2-eloquent/conf/ros-distro/include/eloquent/ros-distro-recipe-blacklist.inc
@@ -11,7 +11,6 @@
 # (none)
 
 # Others
-PNBLACKLIST[libyaml] ?= "Provided by libyaml-vendor"
 
 PNBLACKLIST[ament-clang-format-native] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'clang', 'clang: depends on clang-format', '', d)}"
 PNBLACKLIST[ament-clang-format] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'clang', 'clang: depends on clang-format', '', d)}"

--- a/meta-ros2-eloquent/recipes-bbappends/libyaml-vendor/libyaml-vendor/0001-CMakeLists.txt-use-platform-libyaml-when-available-i.patch
+++ b/meta-ros2-eloquent/recipes-bbappends/libyaml-vendor/libyaml-vendor/0001-CMakeLists.txt-use-platform-libyaml-when-available-i.patch
@@ -1,0 +1,33 @@
+From 1240f9246fb4ffdab1441716fbd35f4eab126f74 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Thu, 9 Jul 2020 01:34:26 -0700
+Subject: [PATCH] CMakeLists.txt: use platform libyaml when available instead
+ of ExternalProject
+
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ CMakeLists.txt | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 99e6826..3ce4e2c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,7 +64,16 @@ macro(build_libyaml)
+   )
+ endmacro()
+ 
+-build_libyaml()
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(YAML REQUIRED yaml-0.1)
++
++if(YAML_FOUND)
++  message(STATUS "Found yaml ${YAML_VERSION}")
++else()
++  message(FATAL_ERROR "yaml not found -- missing from DEPENDS?")
++  # eventually we can build one with ExternalProjectAdd
++  # build_libyaml()
++endif()
+ 
+ ament_export_libraries(yaml)
+ 

--- a/meta-ros2-eloquent/recipes-bbappends/libyaml-vendor/libyaml-vendor_%.bbappend
+++ b/meta-ros2-eloquent/recipes-bbappends/libyaml-vendor/libyaml-vendor_%.bbappend
@@ -1,16 +1,14 @@
 # Copyright (c) 2019-2020 LG Electronics, Inc.
 
-FILES_${PN}-dev_prepend = "${prefix}/cmake "
-SYSROOT_DIRS_append = " ${prefix}/cmake"
+DEPENDS += "libyaml"
 
-PROVIDES += "libyaml"
-RPROVIDES_${PN} += "libyaml"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://0001-CMakeLists.txt-fetch-libyaml-with-bitbake-fetcher.patch \
+    file://0001-CMakeLists.txt-use-platform-libyaml-when-available-i.patch \
+"
 
 # Instead of fetching
 # https://github.com/yaml/libyaml/archive/10c907871f1ccd779c7fccf6b81a62762b5c4e7b.zip
 # during do_compile
-FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
-SRC_URI += "file://0001-CMakeLists.txt-fetch-libyaml-with-bitbake-fetcher.patch \
-    git://github.com/yaml/libyaml.git;protocol=https;branch=release-0.1.8;name=libyaml;destsuffix=git/libyaml-upstream \
-"
-SRCREV_libyaml = "10c907871f1ccd779c7fccf6b81a62762b5c4e7b"
+# git://github.com/yaml/libyaml.git;protocol=https;branch=release-0.1.8;name=libyaml;destsuffix=git/libyaml-upstream \
+# SRCREV_libyaml = "10c907871f1ccd779c7fccf6b81a62762b5c4e7b"

--- a/meta-ros2-eloquent/recipes-bbappends/rcl/rcl-yaml-param-parser/0001-CMakeLists.txt-use-pkg-config-to-find-yaml.patch
+++ b/meta-ros2-eloquent/recipes-bbappends/rcl/rcl-yaml-param-parser/0001-CMakeLists.txt-use-pkg-config-to-find-yaml.patch
@@ -1,0 +1,63 @@
+From b252a4971d827008bbf877402a8ff3a59a42750f Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Thu, 9 Jul 2020 01:44:31 -0700
+Subject: [PATCH] CMakeLists.txt: use pkg-config to find yaml
+
+* yaml-0.1.8 built with CMake in libyaml-vendor ExternalProject_add call
+  provides yamlConfig, but platform yaml-0.2* from oe-core built with
+  autotools provides only pkg-config file yaml-1.0.pc, I've tried to change
+  oe-core recipe from autotools to cmake, but it seems to be broken in
+  upstream libyaml as shown bellow, we should continue to use upstream preferred autotools
+  https://github.com/yaml/libyaml/issues/141
+  https://github.com/yaml/libyaml/issues/138
+
+| CMake Error: File /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/cmake/config.h.in does not exist.
+| CMake Error at CMakeLists.txt:51 (configure_file):
+|   configure_file Problem configuring file
+|
+|
+| CMake Error at CMakeLists.txt:103 (add_subdirectory):
+|   The source directory
+|
+|     /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/tests
+|
+|   does not contain a CMakeLists.txt file.
+|
+|
+| CMake Error: File /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/yamlConfig.cmake.in does not exist.
+| CMake Error at /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/recipe-sysroot-native/usr/share/cmake-3.17/Modules/CMakePackageConfigHelpers.cmake:330 (configure_file):
+|   configure_file Problem configuring file
+| Call Stack (most recent call first):
+|   CMakeLists.txt:114 (configure_package_config_file)
+|
+|
+| CMake Error: File /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/yamlConfig.cmake.in does not exist.
+| CMake Error at /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/recipe-sysroot-native/usr/share/cmake-3.17/Modules/CMakePackageConfigHelpers.cmake:330 (configure_file):
+|   configure_file Problem configuring file
+| Call Stack (most recent call first):
+|   CMakeLists.txt:130 (configure_package_config_file)
+|
+|
+| -- Configuring incomplete, errors occurred!
+| See also "/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/build/CMakeFiles/CMakeOutput.log".
+| WARNING: exit code 1 from a shell command.
+
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 89b089b..dd01e0b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,7 +5,8 @@ project(rcl_yaml_param_parser)
+ find_package(ament_cmake_ros REQUIRED)
+ find_package(rcutils REQUIRED)
+ find_package(libyaml_vendor REQUIRED)
+-find_package(yaml REQUIRED)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(yaml REQUIRED yaml-0.1)
+ 
+ # Default to C++14
+ if(NOT CMAKE_CXX_STANDARD)

--- a/meta-ros2-eloquent/recipes-bbappends/rcl/rcl-yaml-param-parser_0.8.4-1.bbappend
+++ b/meta-ros2-eloquent/recipes-bbappends/rcl/rcl-yaml-param-parser_0.8.4-1.bbappend
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 LG Electronics, Inc.
+
+DEPENDS += "libyaml"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://0001-CMakeLists.txt-use-pkg-config-to-find-yaml.patch"

--- a/meta-ros2-foxy/conf/ros-distro/include/foxy/ros-distro-preferred-providers.inc
+++ b/meta-ros2-foxy/conf/ros-distro/include/foxy/ros-distro-preferred-providers.inc
@@ -4,7 +4,3 @@
 
 # Set PREFERRED_PROVIDER_<PN> here for non-platform packages and to override those set in
 # ros-distro-platform-preferred-providers.inc .
-
-PREFERRED_PROVIDER_libyaml = "libyaml-vendor"
-PREFERRED_PROVIDER_libyaml-dev = "libyaml-vendor-dev"
-PREFERRED_PROVIDER_libyaml-dbg = "libyaml-vendor-dbg"

--- a/meta-ros2-foxy/conf/ros-distro/include/foxy/ros-distro-recipe-blacklist.inc
+++ b/meta-ros2-foxy/conf/ros-distro/include/foxy/ros-distro-recipe-blacklist.inc
@@ -2,8 +2,6 @@
 #
 # Copyright (c) 2020 LG Electronics, Inc.
 
-PNBLACKLIST[libyaml] ?= "Provided by libyaml-vendor"
-
 PNBLACKLIST[ament-clang-format-native] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'clang', 'clang: depends on clang-format', '', d)}"
 PNBLACKLIST[ament-clang-format] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'clang', 'clang: depends on clang-format', '', d)}"
 PNBLACKLIST[ament-clang-tidy-native] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'clang', 'clang: depends on clang-tidy', '', d)}"

--- a/meta-ros2-foxy/recipes-bbappends/libyaml-vendor/libyaml-vendor/0001-CMakeLists.txt-use-platform-libyaml-when-available-i.patch
+++ b/meta-ros2-foxy/recipes-bbappends/libyaml-vendor/libyaml-vendor/0001-CMakeLists.txt-use-platform-libyaml-when-available-i.patch
@@ -1,0 +1,36 @@
+From 6c4b6defe985d1f4f402391fcd2a2a448c818b15 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Thu, 9 Jul 2020 01:34:26 -0700
+Subject: [PATCH] CMakeLists.txt: use platform libyaml when available instead
+ of ExternalProject
+
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ CMakeLists.txt | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9d5785b..2ab0275 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -65,10 +65,18 @@ macro(build_libyaml)
+   )
+ endmacro()
+ 
+-build_libyaml()
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(YAML REQUIRED yaml-0.1)
++
++if(YAML_FOUND)
++  message(STATUS "Found yaml ${YAML_VERSION}")
++else()
++  message(FATAL_ERROR "yaml not found -- missing from DEPENDS?")
++  # eventually we can build one with ExternalProjectAdd
++  # build_libyaml()
++endif()
+ 
+ ament_export_libraries(yaml)
+-ament_export_dependencies(yaml)
+ 
+ if(BUILD_TESTING)
+   find_package(ament_lint_auto REQUIRED)

--- a/meta-ros2-foxy/recipes-bbappends/libyaml-vendor/libyaml-vendor_%.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/libyaml-vendor/libyaml-vendor_%.bbappend
@@ -1,16 +1,14 @@
 # Copyright (c) 2019-2020 LG Electronics, Inc.
 
-FILES_${PN}-dev_prepend = "${prefix}/cmake "
-SYSROOT_DIRS_append = " ${prefix}/cmake"
+DEPENDS += "libyaml"
 
-PROVIDES += "libyaml"
-RPROVIDES_${PN} += "libyaml"
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://0001-CMakeLists.txt-fetch-libyaml-with-bitbake-fetcher.patch \
+    file://0001-CMakeLists.txt-use-platform-libyaml-when-available-i.patch \
+"
 
 # Instead of fetching
 # https://github.com/yaml/libyaml/archive/10c907871f1ccd779c7fccf6b81a62762b5c4e7b.zip
 # during do_compile
-FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
-SRC_URI += "file://0001-CMakeLists.txt-fetch-libyaml-with-bitbake-fetcher.patch \
-    git://github.com/yaml/libyaml.git;protocol=https;branch=release-0.1.8;name=libyaml;destsuffix=git/libyaml-upstream \
-"
-SRCREV_libyaml = "10c907871f1ccd779c7fccf6b81a62762b5c4e7b"
+# git://github.com/yaml/libyaml.git;protocol=https;branch=release-0.1.8;name=libyaml;destsuffix=git/libyaml-upstream \
+# SRCREV_libyaml = "10c907871f1ccd779c7fccf6b81a62762b5c4e7b"

--- a/meta-ros2-foxy/recipes-bbappends/rcl/rcl-yaml-param-parser/0001-CMakeLists.txt-use-pkg-config-to-find-yaml.patch
+++ b/meta-ros2-foxy/recipes-bbappends/rcl/rcl-yaml-param-parser/0001-CMakeLists.txt-use-pkg-config-to-find-yaml.patch
@@ -1,0 +1,62 @@
+From 084159269e1b0a3efa8539bc4a2fff9535945798 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Thu, 9 Jul 2020 01:44:31 -0700
+Subject: [PATCH] CMakeLists.txt: use pkg-config to find yaml
+
+* yaml-0.1.8 built with CMake in libyaml-vendor ExternalProject_add call
+  provides yamlConfig, but platform yaml-0.2* from oe-core built with
+  autotools provides only pkg-config file yaml-1.0.pc, I've tried to change
+  oe-core recipe from autotools to cmake, but it seems to be broken in
+  upstream libyaml as shown bellow, we should continue to use upstream preferred autotools
+  https://github.com/yaml/libyaml/issues/141
+  https://github.com/yaml/libyaml/issues/138
+
+| CMake Error: File /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/cmake/config.h.in does not exist.
+| CMake Error at CMakeLists.txt:51 (configure_file):
+|   configure_file Problem configuring file
+|
+|
+| CMake Error at CMakeLists.txt:103 (add_subdirectory):
+|   The source directory
+|
+|     /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/tests
+|
+|   does not contain a CMakeLists.txt file.
+|
+|
+| CMake Error: File /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/yamlConfig.cmake.in does not exist.
+| CMake Error at /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/recipe-sysroot-native/usr/share/cmake-3.17/Modules/CMakePackageConfigHelpers.cmake:330 (configure_file):
+|   configure_file Problem configuring file
+| Call Stack (most recent call first):
+|   CMakeLists.txt:114 (configure_package_config_file)
+|
+|
+| CMake Error: File /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/yaml-0.2.5/yamlConfig.cmake.in does not exist.
+| CMake Error at /OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/recipe-sysroot-native/usr/share/cmake-3.17/Modules/CMakePackageConfigHelpers.cmake:330 (configure_file):
+|   configure_file Problem configuring file
+| Call Stack (most recent call first):
+|   CMakeLists.txt:130 (configure_package_config_file)
+|
+|
+| -- Configuring incomplete, errors occurred!
+| See also "/OE/build/oe-core/tmp-glibc/work/core2-64-oe-linux/libyaml/0.2.5-r0/build/CMakeFiles/CMakeOutput.log".
+| WARNING: exit code 1 from a shell command.
+
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e2d09a7..5e460fc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,6 +5,8 @@ project(rcl_yaml_param_parser)
+ find_package(ament_cmake_ros REQUIRED)
+ find_package(rcutils REQUIRED)
+ find_package(libyaml_vendor REQUIRED)
++find_package(PkgConfig REQUIRED)
++pkg_check_modules(yaml REQUIRED yaml-0.1)
+ 
+ # Default to C++14
+ if(NOT CMAKE_CXX_STANDARD)

--- a/meta-ros2-foxy/recipes-bbappends/rcl/rcl-yaml-param-parser_1.1.5-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/rcl/rcl-yaml-param-parser_1.1.5-1.bbappend
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 LG Electronics, Inc.
+
+DEPENDS += "libyaml"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://0001-CMakeLists.txt-use-pkg-config-to-find-yaml.patch"


### PR DESCRIPTION
* fixes:
  https://github.com/ros/meta-ros/issues/701
  https://github.com/ros/meta-ros/issues/688

Signed-off-by: Martin Jansa <martin.jansa@lge.com>