### PR TITLE
[build] Add support for ROS 2 rolling

### DIFF
--- a/files-contrib/webos-dashing-dunfell.mcf
+++ b/files-contrib/webos-dashing-dunfell.mcf
@@ -12,7 +12,7 @@ Machines = ['qemux86', 'raspberrypi4']
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'dunfell')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'dunfell/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 MetaRosWebos_RepoURL = getenv('MCF_META_ROS_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-ros-webos.git')
 MetaRosWebos_Branch  = getenv('MCF_META_ROS_WEBOS_BRANCH',   'dunfell')
@@ -46,6 +46,7 @@ Layers = [
 ('meta-qt5-compat',           19, MetaWebos_RepoURL,                                        {}, {}),
 ('meta-qt5',                  20, 'git://github.com/meta-qt5/meta-qt5.git',                 {'branch': 'warrior', 'commit': '9248dc7'}, {}),
 
+('meta-ros-backports-gatesgarth' ,36, MetaRos_RepoURL,                                      {}, {}),
 ('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
 ('meta-ros2',                 38, MetaRos_RepoURL,                                          {}, {}),
 ('meta-ros2-dashing',         39, MetaRos_RepoURL,                                          {}, {}),

--- a/files-contrib/webos-dashing-gatesgarth.mcf
+++ b/files-contrib/webos-dashing-gatesgarth.mcf
@@ -12,7 +12,7 @@ Machines = ['qemux86', 'raspberrypi4']
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'master')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'master/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 MetaRosWebos_RepoURL = getenv('MCF_META_ROS_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-ros-webos.git')
 MetaRosWebos_Branch  = getenv('MCF_META_ROS_WEBOS_BRANCH',   'master')

--- a/files-contrib/webos-eloquent-dunfell.mcf
+++ b/files-contrib/webos-eloquent-dunfell.mcf
@@ -12,7 +12,7 @@ Machines = ['qemux86', 'raspberrypi4']
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'dunfell')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'dunfell/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 MetaRosWebos_RepoURL = getenv('MCF_META_ROS_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-ros-webos.git')
 MetaRosWebos_Branch  = getenv('MCF_META_ROS_WEBOS_BRANCH',   'dunfell')
@@ -46,6 +46,7 @@ Layers = [
 ('meta-qt5-compat',           19, MetaWebos_RepoURL,                                        {}, {}),
 ('meta-qt5',                  20, 'git://github.com/meta-qt5/meta-qt5.git',                 {'branch': 'warrior', 'commit': '9248dc7'}, {}),
 
+('meta-ros-backports-gatesgarth' ,36, MetaRos_RepoURL,                                      {}, {}),
 ('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
 ('meta-ros2',                 38, MetaRos_RepoURL,                                          {}, {}),
 ('meta-ros2-eloquent',        39, MetaRos_RepoURL,                                          {}, {}),

--- a/files-contrib/webos-eloquent-gatesgarth.mcf
+++ b/files-contrib/webos-eloquent-gatesgarth.mcf
@@ -12,7 +12,7 @@ Machines = ['qemux86', 'raspberrypi4']
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'master')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'master/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 MetaRosWebos_RepoURL = getenv('MCF_META_ROS_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-ros-webos.git')
 MetaRosWebos_Branch  = getenv('MCF_META_ROS_WEBOS_BRANCH',   'master')

--- a/files-contrib/webos-foxy-dunfell.mcf
+++ b/files-contrib/webos-foxy-dunfell.mcf
@@ -12,7 +12,7 @@ Machines = ['qemux86', 'raspberrypi4']
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'dunfell')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'dunfell/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 MetaRosWebos_RepoURL = getenv('MCF_META_ROS_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-ros-webos.git')
 MetaRosWebos_Branch  = getenv('MCF_META_ROS_WEBOS_BRANCH',   'dunfell')
@@ -46,6 +46,7 @@ Layers = [
 ('meta-qt5-compat',           19, MetaWebos_RepoURL,                                        {}, {}),
 ('meta-qt5',                  20, 'git://github.com/meta-qt5/meta-qt5.git',                 {'branch': 'warrior', 'commit': '9248dc7'}, {}),
 
+('meta-ros-backports-gatesgarth' ,36, MetaRos_RepoURL,                                      {}, {}),
 ('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
 ('meta-ros2',                 38, MetaRos_RepoURL,                                          {}, {}),
 ('meta-ros2-foxy',            39, MetaRos_RepoURL,                                          {}, {}),

--- a/files-contrib/webos-foxy-gatesgarth.mcf
+++ b/files-contrib/webos-foxy-gatesgarth.mcf
@@ -12,7 +12,7 @@ Machines = ['qemux86', 'raspberrypi4']
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'master')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'master/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 MetaRosWebos_RepoURL = getenv('MCF_META_ROS_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-ros-webos.git')
 MetaRosWebos_Branch  = getenv('MCF_META_ROS_WEBOS_BRANCH',   'master')

--- a/files-contrib/webos-melodic-dunfell.mcf
+++ b/files-contrib/webos-melodic-dunfell.mcf
@@ -12,7 +12,7 @@ Machines = ['qemux86', 'raspberrypi4']
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'dunfell')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'dunfell/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 MetaRosWebos_RepoURL = getenv('MCF_META_ROS_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-ros-webos.git')
 MetaRosWebos_Branch  = getenv('MCF_META_ROS_WEBOS_BRANCH',   'dunfell')
@@ -46,6 +46,7 @@ Layers = [
 ('meta-qt5-compat',           19, MetaWebos_RepoURL,                                        {}, {}),
 ('meta-qt5',                  20, 'git://github.com/meta-qt5/meta-qt5.git',                 {'branch': 'warrior', 'commit': '9248dc7'}, {}),
 
+('meta-ros-backports-gatesgarth' ,36, MetaRos_RepoURL,                                      {}, {}),
 ('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
 ('meta-ros1',                 38, MetaRos_RepoURL,                                          {}, {}),
 ('meta-ros1-melodic',         39, MetaRos_RepoURL,                                          {}, {}),

--- a/files-contrib/webos-melodic-gatesgarth.mcf
+++ b/files-contrib/webos-melodic-gatesgarth.mcf
@@ -12,7 +12,7 @@ Machines = ['qemux86', 'raspberrypi4']
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'master')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'master/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 MetaRosWebos_RepoURL = getenv('MCF_META_ROS_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-ros-webos.git')
 MetaRosWebos_Branch  = getenv('MCF_META_ROS_WEBOS_BRANCH',   'master')

--- a/files-contrib/webos-rolling-dunfell.mcf
+++ b/files-contrib/webos-rolling-dunfell.mcf
@@ -1,0 +1,74 @@
+McfFileVersion = 2
+
+# Value for DISTRO
+Distribution = 'webos'
+
+webOSOSEBuildNumber = 'XXX'
+
+# Supported MACHINE-s
+Machines = ['qemux86', 'raspberrypi4']
+
+# Allow the URL and branch for meta-ros, meta-ros-webos and meta-webos to be overridden by settings in the environment.
+from os import getenv
+MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
+MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'dunfell')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
+
+MetaRosWebos_RepoURL = getenv('MCF_META_ROS_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-ros-webos.git')
+MetaRosWebos_Branch  = getenv('MCF_META_ROS_WEBOS_BRANCH',   'dunfell')
+MetaRosWebos_Commit  = getenv('MCF_META_ROS_WEBOS_COMMIT',   'dunfell/milestones/13')
+
+MetaWebos_RepoURL = getenv('MCF_META_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-webosose.git')
+MetaWebos_Branch  = getenv('MCF_META_WEBOS_BRANCH',   'dunfell')
+MetaWebos_Commit  = getenv('MCF_META_WEBOS_COMMIT',   'dunfell-2020-08-02')
+
+# Layers = [
+# (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),
+# ...
+# ]
+# Note that the github.com/openembedded repositories are read-only mirrors of
+# the authoritative repositories on git.openembedded.org .
+Layers = [
+('bitbake',                   -1, 'git://github.com/openembedded/bitbake.git',              {'branch': '1.46', 'commit': '838a8914'}, {}),
+
+('meta',                       5, 'git://github.com/openembedded/openembedded-core.git',    {'branch': 'dunfell', 'commit': 'b95d6aeafb'}, {}),
+
+('meta-oe',                   10, 'git://github.com/openembedded/meta-openembedded.git',    {'branch': 'dunfell', 'commit': '654ad8bea4'}, {}),
+('meta-multimedia',           11, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
+('meta-networking',           12, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
+('meta-python',               13, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
+('meta-filesystems',          14, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
+
+('meta-updater',              15, 'git://github.com/advancedtelematic/meta-updater.git',    {'branch': 'dunfell', 'commit': 'af3b1db'}, {}),
+('meta-virtualization',       16, 'git://git.yoctoproject.org/meta-virtualization',         {'branch': 'dunfell', 'commit': 'ff997b6'}, {}),
+('meta-python2',              17, 'git://git.openembedded.org/meta-python2',                {'branch': 'dunfell', 'commit': 'e2ef0dd'}, {}),
+
+('meta-qt5-compat',           19, MetaWebos_RepoURL,                                        {}, {}),
+('meta-qt5',                  20, 'git://github.com/meta-qt5/meta-qt5.git',                 {'branch': 'warrior', 'commit': '9248dc7'}, {}),
+
+('meta-ros-backports-gatesgarth' ,36, MetaRos_RepoURL,                                      {}, {}),
+('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
+('meta-ros2',                 38, MetaRos_RepoURL,                                          {}, {}),
+('meta-ros2-rolling',         39, MetaRos_RepoURL,                                          {}, {}),
+
+('meta-webos',                40, MetaWebos_RepoURL,                                        {'branch': MetaWebos_Branch, 'commit': MetaWebos_Commit}, {}),
+
+('meta-raspberrypi',          50, 'git://git.yoctoproject.org/meta-raspberrypi',            {'branch': 'dunfell', 'commit': 'bc7a066'}, {}),
+('meta-webos-raspberrypi',    51, MetaWebos_RepoURL,                                        {}, {}),
+('meta-webos-updater',        52, MetaWebos_RepoURL,                                        {}, {}),
+('meta-webos-virtualization', 53, MetaWebos_RepoURL,                                        {}, {}),
+
+('meta-ros-webos',            60, MetaRosWebos_RepoURL,                                     {'branch': MetaRosWebos_Branch, 'commit': MetaRosWebos_Commit}, {}),
+
+('meta-webos-smack',          75, MetaWebos_RepoURL,                                        {}, {}),
+('meta-security',             77, 'git://git.yoctoproject.org/meta-security',               {'branch': 'dunfell', 'commit': '982a29b'}, {}),
+]
+
+# BblayersConfExtraLines is a list of strings to be appended to the generated
+# conf/bblayers.conf .
+BblayersConfExtraLines = ['MCF_DISTRO ?= "' + Distribution + '"',
+                          'ROS_DISTRO ?= "rolling"',
+                          'MCF_SUPPORTED_MACHINES ?= "' + ' '.join(Machines) + '"',
+                          'MCF_WEBOS_BUILD_NUMBER = "' + webOSOSEBuildNumber + '"',
+                          'MCF_OE_RELEASE_SERIES ?= "dunfell"',
+                         ]

--- a/files-contrib/webos-rolling-gatesgarth.mcf
+++ b/files-contrib/webos-rolling-gatesgarth.mcf
@@ -1,0 +1,73 @@
+McfFileVersion = 2
+
+# Value for DISTRO
+Distribution = 'webos'
+
+webOSOSEBuildNumber = 'XXX'
+
+# Supported MACHINE-s
+Machines = ['qemux86', 'raspberrypi4']
+
+# Allow the URL and branch for meta-ros, meta-ros-webos and meta-webos to be overridden by settings in the environment.
+from os import getenv
+MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
+MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'master')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
+
+MetaRosWebos_RepoURL = getenv('MCF_META_ROS_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-ros-webos.git')
+MetaRosWebos_Branch  = getenv('MCF_META_ROS_WEBOS_BRANCH',   'master')
+MetaRosWebos_Commit  = getenv('MCF_META_ROS_WEBOS_COMMIT',   'master/milestones/13')
+
+MetaWebos_RepoURL = getenv('MCF_META_WEBOS_REPO_URL', 'git://github.com/shr-project/meta-webosose.git')
+MetaWebos_Branch  = getenv('MCF_META_WEBOS_BRANCH',   'master')
+MetaWebos_Commit  = getenv('MCF_META_WEBOS_COMMIT',   'master-2020-08-20')
+
+# Layers = [
+# (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),
+# ...
+# ]
+# Note that the github.com/openembedded repositories are read-only mirrors of
+# the authoritative repositories on git.openembedded.org .
+Layers = [
+('bitbake',                   -1, 'git://github.com/openembedded/bitbake.git',              {'branch': 'master', 'commit': 'ae1aa4ea'}, {}),
+
+('meta',                       5, 'git://github.com/openembedded/openembedded-core.git',    {'branch': 'master', 'commit': '1a2d05b504'}, {}),
+
+('meta-oe',                   10, 'git://github.com/openembedded/meta-openembedded.git',    {'branch': 'master', 'commit': 'ae39f2e711'}, {}),
+('meta-multimedia',           11, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
+('meta-networking',           12, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
+('meta-python',               13, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
+('meta-filesystems',          14, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
+
+('meta-updater',              15, 'git://github.com/advancedtelematic/meta-updater.git',    {'branch': 'master', 'commit': 'd73639e'}, {}),
+('meta-virtualization',       16, 'git://git.yoctoproject.org/meta-virtualization',         {'branch': 'master', 'commit': '65abc71'}, {}),
+('meta-python2',              17, 'git://git.openembedded.org/meta-python2',                {'branch': 'master', 'commit': '285c7a0'}, {}),
+
+('meta-qt5-compat',           19, MetaWebos_RepoURL,                                        {}, {}),
+('meta-qt5',                  20, 'git://github.com/meta-qt5/meta-qt5.git',                 {'branch': 'warrior', 'commit': '9248dc7'}, {}),
+
+('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
+('meta-ros2',                 38, MetaRos_RepoURL,                                          {}, {}),
+('meta-ros2-rolling',         39, MetaRos_RepoURL,                                          {}, {}),
+
+('meta-webos',                40, MetaWebos_RepoURL,                                        {'branch': MetaWebos_Branch, 'commit': MetaWebos_Commit}, {}),
+
+('meta-raspberrypi',          50, 'git://git.yoctoproject.org/meta-raspberrypi',            {'branch': 'master', 'commit': 'cc6074c'}, {}),
+('meta-webos-raspberrypi',    51, MetaWebos_RepoURL,                                        {}, {}),
+('meta-webos-updater',        52, MetaWebos_RepoURL,                                        {}, {}),
+('meta-webos-virtualization', 53, MetaWebos_RepoURL,                                        {}, {}),
+
+('meta-ros-webos',            60, MetaRosWebos_RepoURL,                                     {'branch': MetaRosWebos_Branch, 'commit': MetaRosWebos_Commit}, {}),
+
+('meta-webos-smack',          75, MetaWebos_RepoURL,                                        {}, {}),
+('meta-security',             77, 'git://git.yoctoproject.org/meta-security',               {'branch': 'master', 'commit': '787ba6f'}, {}),
+]
+
+# BblayersConfExtraLines is a list of strings to be appended to the generated
+# conf/bblayers.conf .
+BblayersConfExtraLines = ['MCF_DISTRO ?= "' + Distribution + '"',
+                          'ROS_DISTRO ?= "rolling"',
+                          'MCF_SUPPORTED_MACHINES ?= "' + ' '.join(Machines) + '"',
+                          'MCF_WEBOS_BUILD_NUMBER = "' + webOSOSEBuildNumber + '"',
+                          'MCF_OE_RELEASE_SERIES ?= "gatesgarth"',
+                         ]

--- a/files/ros1-melodic-dunfell.mcf
+++ b/files/ros1-melodic-dunfell.mcf
@@ -42,7 +42,7 @@ OpenEmbeddedVersion = '3.1-320-dunfell'
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'dunfell')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'dunfell/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 # Layers = [
 # (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),
@@ -60,6 +60,7 @@ Layers = [
 
 ('meta-python2',              17, 'git://git.openembedded.org/meta-python2',                {'branch': 'dunfell', 'commit': 'e2ef0dd'}, {}),
 
+('meta-ros-backports-gatesgarth' ,36, MetaRos_RepoURL,                                      {}, {}),
 ('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
 ('meta-ros1',                 38, MetaRos_RepoURL,                                          {}, {}),
 ('meta-ros1-melodic',         39, MetaRos_RepoURL,                                          {}, {}),

--- a/files/ros1-melodic-gatesgarth.mcf
+++ b/files/ros1-melodic-gatesgarth.mcf
@@ -42,7 +42,7 @@ OpenEmbeddedVersion = '3.2~master-gatesgarth'
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'master')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'master/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 # Layers = [
 # (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),

--- a/files/ros2-dashing-dunfell.mcf
+++ b/files/ros2-dashing-dunfell.mcf
@@ -42,7 +42,7 @@ OpenEmbeddedVersion = '3.1-320-dunfell'
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'dunfell')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'dunfell/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 # Layers = [
 # (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),
@@ -58,6 +58,7 @@ Layers = [
 ('meta-oe',                   10, 'git://github.com/openembedded/meta-openembedded.git',    {'branch': 'dunfell', 'commit': '654ad8bea4'}, {}),
 ('meta-python',               13, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
 
+('meta-ros-backports-gatesgarth' ,36, MetaRos_RepoURL,                                      {}, {}),
 ('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
 ('meta-ros2',                 38, MetaRos_RepoURL,                                          {}, {}),
 ('meta-ros2-dashing',         39, MetaRos_RepoURL,                                          {}, {}),

--- a/files/ros2-dashing-gatesgarth.mcf
+++ b/files/ros2-dashing-gatesgarth.mcf
@@ -42,7 +42,7 @@ OpenEmbeddedVersion = '3.2~master-gatesgarth'
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'master')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'master/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 # Layers = [
 # (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),

--- a/files/ros2-eloquent-dunfell.mcf
+++ b/files/ros2-eloquent-dunfell.mcf
@@ -42,7 +42,7 @@ OpenEmbeddedVersion = '3.1-320-dunfell'
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'dunfell')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'dunfell/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 # Layers = [
 # (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),
@@ -58,6 +58,7 @@ Layers = [
 ('meta-oe',                   10, 'git://github.com/openembedded/meta-openembedded.git',    {'branch': 'dunfell', 'commit': '654ad8bea4'}, {}),
 ('meta-python',               13, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
 
+('meta-ros-backports-gatesgarth' ,36, MetaRos_RepoURL,                                      {}, {}),
 ('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
 ('meta-ros2',                 38, MetaRos_RepoURL,                                          {}, {}),
 ('meta-ros2-eloquent',        39, MetaRos_RepoURL,                                          {}, {}),

--- a/files/ros2-eloquent-gatesgarth.mcf
+++ b/files/ros2-eloquent-gatesgarth.mcf
@@ -42,7 +42,7 @@ OpenEmbeddedVersion = '3.2~master-gatesgarth'
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'master')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'master/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 # Layers = [
 # (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),

--- a/files/ros2-foxy-dunfell.mcf
+++ b/files/ros2-foxy-dunfell.mcf
@@ -42,7 +42,7 @@ OpenEmbeddedVersion = '3.1-320-dunfell'
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'dunfell')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'dunfell/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 # Layers = [
 # (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),
@@ -58,6 +58,7 @@ Layers = [
 ('meta-oe',                   10, 'git://github.com/openembedded/meta-openembedded.git',    {'branch': 'dunfell', 'commit': '654ad8bea4'}, {}),
 ('meta-python',               13, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
 
+('meta-ros-backports-gatesgarth' ,36, MetaRos_RepoURL,                                      {}, {}),
 ('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
 ('meta-ros2',                 38, MetaRos_RepoURL,                                          {}, {}),
 ('meta-ros2-foxy',            39, MetaRos_RepoURL,                                          {}, {}),

--- a/files/ros2-foxy-gatesgarth.mcf
+++ b/files/ros2-foxy-gatesgarth.mcf
@@ -42,7 +42,7 @@ OpenEmbeddedVersion = '3.2~master-gatesgarth'
 from os import getenv
 MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
 MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'master')
-MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   'master/milestones/13')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
 
 # Layers = [
 # (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),

--- a/files/ros2-rolling-dunfell.mcf
+++ b/files/ros2-rolling-dunfell.mcf
@@ -1,0 +1,76 @@
+# Copyright (c) 2019-2020 LG Electronics, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+McfFileVersion = 2
+
+# Value for DISTRO
+Distribution = 'ros2'
+
+# Supported MACHINE-s
+Machines = ['qemux86-64', 'raspberrypi4-64']
+
+# The format of OpenEmbeddedVersion is:
+#   <YOCTO-VERSION>[.<N>]-<OPENEMBEDDED-RELEASE-SERIES>
+# <YOCTO-VERSION> is the second and third hyphen-separated fields of the output
+# from:
+#   git describe --match yocto-* <COMMIT>
+# executed in a checkout of openembedded-core.git, where <COMMIT> is the commit
+# to which the 'meta' layer is pinned in Layers[]. Include the optional ".<N>"
+# when the 'meta' layer pin is unchanged, but those of other upstream layers
+# have been. If a ".<N>" is to be added and there is no hyphen in
+# <YOCTO-VERSION>, append "-0" to it.
+#
+# This scheme is modified when used for the <OPENEMBEDDED-RELEASE-SERIES> being
+# developed in the [master] branch: "git describe" is not used to form
+# <YOCTO-VERSION>; instead it is the value in the Yocto Project Version column
+# of https://wiki.yoctoproject.org/wiki/Releases for
+# <OPENEMBEDDED-RELEASE-SERIES> to which a constant "~master" is appended.
+OpenEmbeddedVersion = '3.1-320-dunfell'
+
+# Allow the URL and branch for meta-ros to be overridden by settings in the environment.
+from os import getenv
+MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
+MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'dunfell')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
+
+# Layers = [
+# (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),
+# ...
+# ]
+# Note that the github.com/openembedded repositories are read-only mirrors of
+# the authoritative repositories on git.openembedded.org .
+Layers = [
+('bitbake',                   -1, 'git://github.com/openembedded/bitbake.git',              {'branch': '1.46', 'commit': '838a8914'}, {}),
+
+('meta',                       5, 'git://github.com/openembedded/openembedded-core.git',    {'branch': 'dunfell', 'commit': 'b95d6aeafb'}, {}),
+
+('meta-oe',                   10, 'git://github.com/openembedded/meta-openembedded.git',    {'branch': 'dunfell', 'commit': '654ad8bea4'}, {}),
+('meta-python',               13, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
+
+('meta-ros-backports-gatesgarth' ,36, MetaRos_RepoURL,                                      {}, {}),
+('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
+('meta-ros2',                 38, MetaRos_RepoURL,                                          {}, {}),
+('meta-ros2-rolling',         39, MetaRos_RepoURL,                                          {}, {}),
+
+('meta-raspberrypi',          50, 'git://git.yoctoproject.org/meta-raspberrypi',            {'branch': 'dunfell', 'commit': 'bc7a066'}, {}),
+]
+
+# BblayersConfExtraLines is a list of strings to be appended to the generated
+# conf/bblayers.conf .
+BblayersConfExtraLines = ['MCF_DISTRO ?= "' + Distribution + '"',
+                          'ROS_DISTRO ?= "rolling"',
+                          'MCF_SUPPORTED_MACHINES ?= "' + ' '.join(Machines) + '"',
+                          'MCF_OPENEMBEDDED_VERSION ?= "' + OpenEmbeddedVersion + '"',
+                          'MCF_OE_RELEASE_SERIES ?= "dunfell"',
+                         ]

--- a/files/ros2-rolling-gatesgarth.mcf
+++ b/files/ros2-rolling-gatesgarth.mcf
@@ -1,0 +1,75 @@
+# Copyright (c) 2019-2020 LG Electronics, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+McfFileVersion = 2
+
+# Value for DISTRO
+Distribution = 'ros2'
+
+# Supported MACHINE-s
+Machines = ['qemux86-64', 'raspberrypi4-64']
+
+# The format of OpenEmbeddedVersion is:
+#   <YOCTO-VERSION>[.<N>]-<OPENEMBEDDED-RELEASE-SERIES>
+# <YOCTO-VERSION> is the second and third hyphen-separated fields of the output
+# from:
+#   git describe --match yocto-* <COMMIT>
+# executed in a checkout of openembedded-core.git, where <COMMIT> is the commit
+# to which the 'meta' layer is pinned in Layers[]. Include the optional ".<N>"
+# when the 'meta' layer pin is unchanged, but those of other upstream layers
+# have been. If a ".<N>" is to be added and there is no hyphen in
+# <YOCTO-VERSION>, append "-0" to it.
+#
+# This scheme is modified when used for the <OPENEMBEDDED-RELEASE-SERIES> being
+# developed in the [master] branch: "git describe" is not used to form
+# <YOCTO-VERSION>; instead it is the value in the Yocto Project Version column
+# of https://wiki.yoctoproject.org/wiki/Releases for
+# <OPENEMBEDDED-RELEASE-SERIES> to which a constant "~master" is appended.
+OpenEmbeddedVersion = '3.2~master-gatesgarth'
+
+# Allow the URL and branch for meta-ros to be overridden by settings in the environment.
+from os import getenv
+MetaRos_RepoURL = getenv('MCF_META_ROS_REPO_URL', 'git://github.com/ros/meta-ros.git')
+MetaRos_Branch  = getenv('MCF_META_ROS_BRANCH',   'master')
+MetaRos_Commit  = getenv('MCF_META_ROS_COMMIT',   '9ee61883026bcd2a88a21683591177fa4674e523')
+
+# Layers = [
+# (layer-name: str, priority: int, URL: str, fetch: dict, options: dict),
+# ...
+# ]
+# Note that the github.com/openembedded repositories are read-only mirrors of
+# the authoritative repositories on git.openembedded.org .
+Layers = [
+('bitbake',                   -1, 'git://github.com/openembedded/bitbake.git',              {'branch': 'master', 'commit': 'ae1aa4ea'}, {}),
+
+('meta',                       5, 'git://github.com/openembedded/openembedded-core.git',    {'branch': 'master', 'commit': '1a2d05b504'}, {}),
+
+('meta-oe',                   10, 'git://github.com/openembedded/meta-openembedded.git',    {'branch': 'master', 'commit': 'ae39f2e711'}, {}),
+('meta-python',               13, 'git://github.com/openembedded/meta-openembedded.git',    {}, {}),
+
+('meta-ros-common',           37, MetaRos_RepoURL,                                          {'branch': MetaRos_Branch, 'commit': MetaRos_Commit}, {}),
+('meta-ros2',                 38, MetaRos_RepoURL,                                          {}, {}),
+('meta-ros2-rolling',         39, MetaRos_RepoURL,                                          {}, {}),
+
+('meta-raspberrypi',          50, 'git://git.yoctoproject.org/meta-raspberrypi',            {'branch': 'master', 'commit': 'cc6074c'}, {}),
+]
+
+# BblayersConfExtraLines is a list of strings to be appended to the generated
+# conf/bblayers.conf .
+BblayersConfExtraLines = ['MCF_DISTRO ?= "' + Distribution + '"',
+                          'ROS_DISTRO ?= "rolling"',
+                          'MCF_SUPPORTED_MACHINES ?= "' + ' '.join(Machines) + '"',
+                          'MCF_OPENEMBEDDED_VERSION ?= "' + OpenEmbeddedVersion + '"',
+                          'MCF_OE_RELEASE_SERIES ?= "gatesgarth"',
+                         ]


### PR DESCRIPTION
Depends on https://github.com/ros/meta-ros/pull/717 - only the last 4 commits are needed for rolling.