### PR TITLE
*/conf/layer.conf: adjust the default BBFILE_PRIORITY

### DIFF
--- a/meta-ros-backports-gatesgarth/conf/layer.conf
+++ b/meta-ros-backports-gatesgarth/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "ros-backports-gatesgarth-layer"
 BBFILE_PATTERN_ros-backports-gatesgarth-layer := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros-backports-gatesgarth-layer = "7"
+BBFILE_PRIORITY_ros-backports-gatesgarth-layer = "9"
 
 # Version 1 was the manually created meta-ros, prior to the introduction of superflore.
 # Version 2 was all ROS distributions in the same meta-ros layer with right subdirectories selected by ROS_DISTRO variable

--- a/meta-ros-common/conf/layer.conf
+++ b/meta-ros-common/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "ros-common-layer"
 BBFILE_PATTERN_ros-common-layer := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros-common-layer = "7"
+BBFILE_PRIORITY_ros-common-layer = "10"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 

--- a/meta-ros-python2/conf/layer.conf
+++ b/meta-ros-python2/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "ros-python2"
 BBFILE_PATTERN_ros-python2 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros-python2 = "7"
+BBFILE_PRIORITY_ros-python2 = "9"
 
 # Version 1 was the manually created meta-ros, prior to the introduction of superflore.
 # Version 2 was all ROS distributions in the same meta-ros layer with right subdirectories selected by ROS_DISTRO variable

--- a/meta-ros1-melodic/conf/layer.conf
+++ b/meta-ros1-melodic/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend ${LA
 
 BBFILE_COLLECTIONS += "ros1-melodic-layer"
 BBFILE_PATTERN_ros1-melodic-layer := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros1-melodic-layer = "7"
+BBFILE_PRIORITY_ros1-melodic-layer = "12"
 
 # Version 1 was the manually created meta-ros, prior to the introduction of superflore.
 # Version 2 was all ROS distributions in the same meta-ros layer with right subdirectories selected by ROS_DISTRO variable

--- a/meta-ros1/conf/layer.conf
+++ b/meta-ros1/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "ros1-layer"
 BBFILE_PATTERN_ros1-layer := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros1-layer = "7"
+BBFILE_PRIORITY_ros1-layer = "11"
 
 # Version 1 was the manually created meta-ros, prior to the introduction of superflore.
 # Version 2 was all ROS distributions in the same meta-ros layer with right subdirectories selected by ROS_DISTRO variable

--- a/meta-ros2-dashing/conf/layer.conf
+++ b/meta-ros2-dashing/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend ${LA
 
 BBFILE_COLLECTIONS += "ros2-dashing-layer"
 BBFILE_PATTERN_ros2-dashing-layer := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros2-dashing-layer = "7"
+BBFILE_PRIORITY_ros2-dashing-layer = "12"
 
 # Version 1 was the manually created meta-ros2-dashing, prior to the introduction of superflore.
 # Version 2 was all ROS distributions in the same meta-ros layer with right subdirectories selected by ROS_DISTRO variable

--- a/meta-ros2-eloquent/conf/layer.conf
+++ b/meta-ros2-eloquent/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend ${LA
 
 BBFILE_COLLECTIONS += "ros2-eloquent-layer"
 BBFILE_PATTERN_ros2-eloquent-layer := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros2-eloquent-layer = "7"
+BBFILE_PRIORITY_ros2-eloquent-layer = "12"
 
 # Version 1 was the manually created meta-ros, prior to the introduction of superflore.
 # Version 2 was all ROS distributions in the same meta-ros layer with right subdirectories selected by ROS_DISTRO variable

--- a/meta-ros2-foxy/conf/layer.conf
+++ b/meta-ros2-foxy/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend ${LA
 
 BBFILE_COLLECTIONS += "ros2-foxy-layer"
 BBFILE_PATTERN_ros2-foxy-layer := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros2-foxy-layer = "7"
+BBFILE_PRIORITY_ros2-foxy-layer = "12"
 
 # Version 1 was the manually created meta-ros, prior to the introduction of superflore.
 # Version 2 was all ROS distributions in the same meta-ros layer with right subdirectories selected by ROS_DISTRO variable

--- a/meta-ros2-rolling/conf/layer.conf
+++ b/meta-ros2-rolling/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend ${LA
 
 BBFILE_COLLECTIONS += "ros2-rolling-layer"
 BBFILE_PATTERN_ros2-rolling-layer := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros2-rolling-layer = "7"
+BBFILE_PRIORITY_ros2-rolling-layer = "12"
 
 # Version 1 was the manually created meta-ros, prior to the introduction of superflore.
 # Version 2 was all ROS distributions in the same meta-ros layer with right subdirectories selected by ROS_DISTRO variable

--- a/meta-ros2/conf/layer.conf
+++ b/meta-ros2/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "ros2-layer"
 BBFILE_PATTERN_ros2-layer := "^${LAYERDIR}/"
-BBFILE_PRIORITY_ros2-layer = "7"
+BBFILE_PRIORITY_ros2-layer = "11"
 
 # Version 1 was the manually created meta-ros, prior to the introduction of superflore.
 # Version 2 was all ROS distributions in the same meta-ros layer with right subdirectories selected by ROS_DISTRO variable


### PR DESCRIPTION
* BBFILE_PRIORITY is important when there is the same recipe in
  multiple layers:
  https://www.yoctoproject.org/docs/3.1.3/mega-manual/mega-manual.html#var-BBFILE_PRIORITY
  https://www.yoctoproject.org/docs/3.1.3/mega-manual/mega-manual.html#prioritizing-your-layer

* in our builds configured with mcf tool according to:
  https://github.com/ros/meta-ros/wiki/OpenEmbedded-Build-Instructions
  we don't use these BBFILE_PRIORITY values from layer.conf, but instead
  override them with the values defined in .mcf files and we use this
  priority also to sort the layers in conf/bblayers.conf's BBLAYERS variable
  which is also very important as it in the end affects how BBPATH is constructed:
  https://www.yoctoproject.org/docs/3.1.3/mega-manual/mega-manual.html#var-BBLAYERS
  https://www.yoctoproject.org/docs/3.1.3/mega-manual/mega-manual.html#var-BBPATH

  so with our .mcf files we're currently using these values e.g. in
  https://github.com/ros/meta-ros/blob/e69530c091b62c34754f1983a99417c95f5925b1/files/ros1-melodic-dunfell.mcf
  (sorted by priority):

  BBFILE_PRIORITY_core_forcevariable = "5"
  BBFILE_PRIORITY_openembedded-layer_forcevariable = "10"
  BBFILE_PRIORITY_meta-python_forcevariable = "13"
  BBFILE_PRIORITY_meta-python2_forcevariable = "17"
  BBFILE_PRIORITY_ros-python2_forcevariable = "35"
  BBFILE_PRIORITY_ros-common-layer_forcevariable = "37"
  BBFILE_PRIORITY_ros1-layer_forcevariable = "38"
  BBFILE_PRIORITY_ros1-melodic-layer_forcevariable = "39"
  BBFILE_PRIORITY_raspberrypi_forcevariable = "50"

  which matches the dependency tree between layers as defined by LAYERDEPENDS variables
  https://www.yoctoproject.org/docs/3.1.3/mega-manual/mega-manual.html#var-LAYERDEPENDS

  that's why we never paid much attention to default BBFILE_PRIORITY values in layer.conf
  as we're not using them (and all were set to 7), but as shown in:
  https://github.com/ros/meta-ros/commit/a2abbc6022c89cadf2900522ee0b0616acf6d6ba#commitcomment-43818858
  discussion, some people aren't aware of BBFILE_PRIORITY importance
  and aren't used to override them in their build setup, lets adjust
  the default values so that they follow the LAYERDEPENDS ordering
  as well:

  BBFILE_PRIORITY_ros-python2 = "9"
  BBFILE_PRIORITY_ros-backports-gatesgarth-layer = "9"

  BBFILE_PRIORITY_ros-common-layer = "10"

  BBFILE_PRIORITY_ros1-layer = "11"
  BBFILE_PRIORITY_ros2-layer = "11"

  BBFILE_PRIORITY_ros1-melodic-layer = "12"
  BBFILE_PRIORITY_ros2-dashing-layer = "12"
  BBFILE_PRIORITY_ros2-eloquent-layer = "12"
  BBFILE_PRIORITY_ros2-foxy-layer = "12"
  BBFILE_PRIORITY_ros2-rolling-layer = "12"

  these default values are better, because now console-bridge
  from meta-ros1 layer will be used instead of the one in meta-ros-common,
  but it's still just some default which might not work well for
  everybody, e.g. if you had your own layer meta-<my-distro> with
  BBFILE_PRIORITY 10, then it was working well to overlay recipes
  in most public layers (e.g. meta-raspberrypi has 9,
  meta-virtualization 8), but now 10 won't be enough to overlay
  recipe e.g. from meta-ros2-foxy with 12, so be aware of this
  behavior and adjust accordingly.

* there is still a way to select the recipe version you want to use
  with PREFERRED_VERSION (as log as PV is different in those recipes)
  or using BBMASK to mask the one you don't want to use, but BBFILE_PRIORITY
  is still more elegant and easier to use (as long as the values used
  in your project make sense).

Signed-off-by: Martin Jansa <martin.jansa@lge.com>