### PR TITLE
fix dependencies for some foxy msgs/srvs.

### DIFF
--- a/meta-ros2-foxy/recipes-bbappends/common-interfaces/std-srvs_2.0.3-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/common-interfaces/std-srvs_2.0.3-1.bbappend
@@ -4,3 +4,20 @@
 ROS_BUILD_DEPENDS += " \
     rosidl-default-runtime \
 "
+
+ROS_BUILD_DEPENDS += " \
+    builtin-interfaces \
+    rosidl-typesupport-c \
+    rosidl-typesupport-cpp \
+"
+ROS_BUILDTOOL_DEPENDS += " \
+    rosidl-parser-native \
+    rosidl-adapter-native \
+    rosidl-typesupport-fastrtps-cpp-native \
+    rosidl-typesupport-fastrtps-c-native \
+    python3-numpy-native \
+    python3-lark-parser-native \
+"
+ROS_EXEC_DEPENDS += " \
+    builtin-interfaces \
+"

--- a/meta-ros2-foxy/recipes-bbappends/rcl-interfaces/lifecycle-msgs_1.0.0-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/rcl-interfaces/lifecycle-msgs_1.0.0-1.bbappend
@@ -4,3 +4,20 @@
 ROS_BUILD_DEPENDS += " \
     rosidl-default-runtime \
 "
+
+ROS_BUILD_DEPENDS += " \
+    fastcdr \
+    fastrtps \
+    builtin-interfaces \
+    rosidl-typesupport-fastrtps-c \
+    rosidl-typesupport-fastrtps-cpp \
+    rosidl-typesupport-fastrtps-c-native \
+    rosidl-typesupport-fastrtps-cpp-native \
+"
+
+ROS_BUILDTOOL_DEPENDS += " \
+    rosidl-parser-native \
+    rosidl-adapter-native \
+    python3-numpy-native \
+    python3-lark-parser-native \
+"

--- a/meta-ros2-foxy/recipes-bbappends/unique-identifier-msgs/unique-identifier-msgs_2.1.2-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/unique-identifier-msgs/unique-identifier-msgs_2.1.2-1.bbappend
@@ -4,3 +4,20 @@
 ROS_BUILD_DEPENDS += " \
     rosidl-default-runtime \
 "
+
+ROS_BUILD_DEPENDS += " \
+    fastcdr \
+    fastrtps \
+    builtin-interfaces \
+    rosidl-typesupport-fastrtps-c \
+    rosidl-typesupport-fastrtps-cpp \
+    rosidl-typesupport-fastrtps-c-native \
+    rosidl-typesupport-fastrtps-cpp-native \
+"
+
+ROS_BUILDTOOL_DEPENDS += " \
+    rosidl-parser-native \
+    rosidl-adapter-native \
+    python3-numpy-native \
+    python3-lark-parser-native \
+"


### PR DESCRIPTION
Based on the latest version of navigation2(V0.4.3) integrated into this repo, I found some build/runtime errors when launching Navigation2 demo apps, and evaluated their root-causes and provided the solution. Please have a review. @shr-project .

To make the build/launching correctly, some items relevant to navigation2 stack in ros-distro-blacklist should also be removed.