### PR TITLE
[thud] README.md: Update for the dropping of support for building with thud in Milestone 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-# Branch `[thud]`
+# Branch `[thud]` (UNSUPPORTED)
 
-As of 2020-07-04, this branch can be used to build the February and March 2020
-releases of ROS 2 **dashing**, ROS 2 **eloquent**, and ROS 1 **melodic**, and
-the 2020-06-25 release of ROS 2 **foxy**.
+The **thud** OpenEmbedded release series has reached its EOL (see
+https://wiki.yoctoproject.org/wiki/Releases). Support for ROS distro releases
+newer than those of Milestone 13 (2020-07-04) has not been added to this branch,
+and, following the
+[OpenEmbedded Release Series Support Policy](https://github.com/ros/meta-ros/wiki/Policies#openembedded-release-series-support),
+building with **thud** is no longer supported as of Milestone 15 (2020-12-23).
 
-See [here](https://github.com/ros/meta-ros/wiki/OpenEmbedded-Build-Instructions)
-for instructions.
+Instructions for using `meta-ros` are
+[here](https://github.com/ros/meta-ros/wiki/OpenEmbedded-Build-Instructions).
+
 
 ## History
 


### PR DESCRIPTION
Also mention that support for ROS distro releases newer than those of
Milestone 13 has not been added.