### PR TITLE
[dunfell] {eloquent} librealsense2: fetch firmware files with bitbake fetcher

### DIFF
--- a/meta-ros2-eloquent/recipes-bbappends/librealsense2/librealsense2/0001-common-fw-CMakeLists.txt-respect-_FW_URL-when-set.patch
+++ b/meta-ros2-eloquent/recipes-bbappends/librealsense2/librealsense2/0001-common-fw-CMakeLists.txt-respect-_FW_URL-when-set.patch
@@ -1,0 +1,55 @@
+From fb2decd9bbb9f4ff557637994314699d0328ed56 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Thu, 21 May 2020 10:14:23 +0000
+Subject: [PATCH] common/fw/CMakeLists.txt: respect *_FW_URL when set
+
+Upstream-Status: Pending
+
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ common/fw/CMakeLists.txt | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/common/fw/CMakeLists.txt b/common/fw/CMakeLists.txt
+index 1420e85..6c013d6 100644
+--- a/common/fw/CMakeLists.txt
++++ b/common/fw/CMakeLists.txt
+@@ -15,26 +15,34 @@ string(REGEX MATCH "D4XX_RECOMMENDED_FIRMWARE_VERSION \"([0-9]+.[0-9]+.[0-9]+.[0
+ set(D4XX_FW_VERSION ${CMAKE_MATCH_1})
+ message(STATUS "D4XX_FW_VERSION: ${D4XX_FW_VERSION}")
+ set(D4XX_FW_SHA1 dc690d0a6ed113eee8ed41a0c1589c58975bd724)
+-set(D4XX_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/RS4xx/FW")
++if (NOT DEFINED D4XX_FW_URL)
++  set(D4XX_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/RS4xx/FW")
++endif()
+ 
+ 
+ string(REGEX MATCH "SR3XX_RECOMMENDED_FIRMWARE_VERSION \"([0-9]+.[0-9]+.[0-9]+.[0-9]+)\"" _ ${ver})
+ set(SR3XX_FW_VERSION ${CMAKE_MATCH_1})
+ message(STATUS "SR3XX_FW_VERSION: ${SR3XX_FW_VERSION}")
+ set(SR3XX_FW_SHA1 55237dba5d7db20e7c218975375d05b4210e9460)
+-set(SR3XX_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/SR300/FW")
++if (NOT DEFINED SR3XX_FW_URL)
++  set(SR3XX_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/SR300/FW")
++endif()
+ 
+ string(REGEX MATCH "T26X_FIRMWARE_VERSION \"([0-9]+.[0-9]+.[0-9]+.[0-9]+)\"" _ ${ver})
+ set(T26X_FW_VERSION ${CMAKE_MATCH_1})
+ message(STATUS "T26X_FW_VERSION: ${T26X_FW_VERSION}")
+ set(T26X_FW_SHA1 c3940ccbb0e3045603e4aceaa2d73427f96e24bc)
+-set(T26X_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/TM2/FW/target/${T26X_FW_VERSION}")
++if (NOT DEFINED T26X_FW_URL)
++  set(T26X_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/TM2/FW/target/${T26X_FW_VERSION}")
++endif()
+ 
+ string(REGEX MATCH "L5XX_RECOMMENDED_FIRMWARE_VERSION \"([0-9]+.[0-9]+.[0-9]+.[0-9]+)\"" _ ${ver})
+ set(L5XX_FW_VERSION ${CMAKE_MATCH_1})
+ message(STATUS "L5XX_FW_VERSION: ${L5XX_FW_VERSION}")
+ set(L5XX_FW_SHA1 024cc496856db78569edecbbbf681aafd566b41d)
+-set(L5XX_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/L5xx/FW")
++if (NOT DEFINED L5XX_FW_URL)
++  set(L5XX_FW_URL "${REALSENSE_FIRMWARE_URL}/Releases/L5xx/FW")
++endif()
+ 
+ add_library(${PROJECT_NAME} STATIC empty.c)
+ 

--- a/meta-ros2-eloquent/recipes-bbappends/librealsense2/librealsense2_%.bbappend
+++ b/meta-ros2-eloquent/recipes-bbappends/librealsense2/librealsense2_%.bbappend
@@ -1,5 +1,27 @@
-# Copyright (c) 2020 LG Electronics, Inc.
+# Copyright (c) 2020-2021 LG Electronics, Inc.
 
 # ERROR: librealsense2-2.38.1-4-r0 do_package_qa: QA Issue:
 # non -dev/-dbg/nativesdk- package contains symlink .so: librealsense2 path '/work/core2-64-oe-linux/librealsense2/2.38.1-4-r0/packages-split/librealsense2/usr/lib/librealsense2.so' [dev-so]
 inherit ros_insane_dev_so
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+SRC_URI_FW = "http://realsense-hw-public.s3.amazonaws.com/Releases"
+SRC_URI += " \
+    file://0001-common-fw-CMakeLists.txt-respect-_FW_URL-when-set.patch \
+    ${SRC_URI_FW}/RS4xx/FW/D4XX_FW_Image-5.12.7.100.bin;name=D4XX_FW \
+    ${SRC_URI_FW}/SR300/FW/SR3XX_FW_Image-3.26.1.0.bin;name=SR3XX_FW \
+    ${SRC_URI_FW}/TM2/FW/target/0.2.0.951/target-0.2.0.951.mvcmd;name=T26X_FW \
+    ${SRC_URI_FW}/L5xx/FW/L5XX_FW_Image-1.5.0.0.bin;name=L5XX_FW \
+"
+
+SRC_URI[D4XX_FW.sha256sum] = "f6a06019a59b963c6e53a5299af49a4e375989866587c20c17d432b689679b50"
+SRC_URI[SR3XX_FW.sha256sum] = "c4ac2144df13c3a64fca9d16c175595c903e6e45f02f0f238630a223b07c14d1"
+SRC_URI[T26X_FW.sha256sum] = "0265fd111611908b822cdaf4a3fe5b631c50539b2805d2f364c498aa71c007c0"
+SRC_URI[L5XX_FW.sha256sum] = "0266d63992ce461a087293b0e87cd0bf79e404854c08aa612781db73419de5a8"
+
+EXTRA_OECMAKE += " \
+  -DD4XX_FW_URL=file://${WORKDIR} \
+  -DSR3XX_FW_URL=file://${WORKDIR} \
+  -DT26X_FW_URL=file://${WORKDIR} \
+  -DL5XX_FW_URL=file://${WORKDIR} \
+"


### PR DESCRIPTION
* similarly like in foxy bbappend
* prevents random build failures during network glitches like:

-- Fetching recommended firmwares:
-- D4XX_FW_VERSION: 5.12.7.100
-- SR3XX_FW_VERSION: 3.26.1.0
-- T26X_FW_VERSION: 0.2.0.951
-- L5XX_FW_VERSION: 1.5.0.0
-- http://realsense-hw-public.s3.amazonaws.com/Releases/RS4xx/FW/D4XX_FW_Image-5.12.7.100.bin
CMake Error at common/fw/CMakeLists.txt:55 (file):
  file DOWNLOAD HASH mismatch

    for file: [core2-32-oe-linux/librealsense2/2.38.1-4-r0/build/common/fw/D4XX_FW_Image-5.12.7.100.bin]
      expected hash: [dc690d0a6ed113eee8ed41a0c1589c58975bd724]
        actual hash: [da39a3ee5e6b4b0d3255bfef95601890afd80709]
             status: [6;"Couldn't resolve host name"]

Call Stack (most recent call first):
  common/fw/CMakeLists.txt:80 (target_binary)

-- http://realsense-hw-public.s3.amazonaws.com/Releases/SR300/FW/SR3XX_FW_Image-3.26.1.0.bin
-- Download firmware 0;"No error" for SR3XX_FW_Image-3.26.1.0.bin
-- http://realsense-hw-public.s3.amazonaws.com/Releases/TM2/FW/target/0.2.0.951/target-0.2.0.951.mvcmd
-- Download firmware 0;"No error" for target-0.2.0.951.mvcmd
-- http://realsense-hw-public.s3.amazonaws.com/Releases/L5xx/FW/L5XX_FW_Image-1.5.0.0.bin
-- Download firmware 0;"No error" for L5XX_FW_Image-1.5.0.0.bin
-- Configuring incomplete, errors occurred!

Signed-off-by: Martin Jansa <martin.jansa@lge.com>