### PR TITLE
[dunfell][gatesgarth][master] ros-python2-recipe-blacklist.inc: unblacklist mongodb

### DIFF
--- a/meta-ros-common/conf/distro/include/ros-python2-recipe-blacklist.inc
+++ b/meta-ros-common/conf/distro/include/ros-python2-recipe-blacklist.inc
@@ -8,8 +8,6 @@ PNBLACKLIST[python] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'python2',
 PNBLACKLIST[gammu] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'python2', 'Depends on blacklisted python2', '', d)}"
 # meta-openembedded/meta-oe/recipes-connectivity/thrift/thrift_0.9.3.bb
 PNBLACKLIST[thrift] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'python2', 'Depends on blacklisted python2', '', d)}"
-# meta-openembedded/meta-oe/recipes-dbs/mongodb/mongodb_git.bb
-PNBLACKLIST[mongodb] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'python2', 'Depends on blacklisted python2', '', d)}"
 # meta-openembedded/meta-oe/recipes-dbs/mysql/mysql-python_1.2.5.bb
 PNBLACKLIST[mysql-python] ?= "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'python2', 'Depends on blacklisted python2', '', d)}"
 # meta-openembedded/meta-oe/recipes-dbs/postgresql/postgresql_10.10.bb


### PR DESCRIPTION
* it uses python3 since zeus with 4.2 version introduced in:
  https://git.openembedded.org/meta-openembedded/commit/?id=1849429a791457250236778793c36a12f0df3194

* fixes:
  ERROR: Nothing PROVIDES 'mongodb' (but /meta-ros2-foxy/generated-recipes/warehouse-ros-mongo/warehouse-ros-mongo_2.0.0-1.bb DEPENDS on or otherwise requires it)
  mongodb was skipped: Recipe is blacklisted: Depends on blacklisted python2
  NOTE: Runtime target 'warehouse-ros-mongo' is unbuildable, removing...
  Missing or unbuildable dependency chain was: ['warehouse-ros-mongo', 'mongodb']

Signed-off-by: Martin Jansa <martin.jansa@lge.com>