### PR TITLE
[zeus] {foxy} (test-)osrf-testing-tools-cpp: disable branch check with nobranch=1

### DIFF
--- a/meta-ros2-foxy/recipes-bbappends/osrf-testing-tools-cpp/osrf-testing-tools-cpp_1.3.2-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/osrf-testing-tools-cpp/osrf-testing-tools-cpp_1.3.2-1.bbappend
@@ -1,8 +1,4 @@
-# Copyright (c) 2019-2021 LG Electronics, Inc.
-
-DEPENDS += " \
-    osrf-testing-tools-cpp \
-"
+# Copyright (c) 2021 LG Electronics, Inc.
 
 # dashing, foxy, eloquent branches were deleted for some reason, reported at https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/issues/2
 ROS_BRANCH = "nobranch=1"


### PR DESCRIPTION
fixes https://github.com/ros/meta-ros/issues/815
