### PR TITLE
[dunfell][gatesgarth][hardknott][master] {foxy} build improvements for rviz

### DIFF
--- a/meta-ros-common/recipes-devtools/ogre/ogre_1.12.8.bb
+++ b/meta-ros-common/recipes-devtools/ogre/ogre_1.12.8.bb
@@ -18,7 +18,7 @@ inherit cmake features_check
 
 REQUIRED_DISTRO_FEATURES = "x11"
 
-DEPENDS = "zlib libx11 pugixml freetype"
+DEPENDS = "zlib libx11 pugixml freetype virtual/libgl libglu"
 
 # extra flags from rviz-ogre-vendor ExternalProject_Add in:
 # https://github.com/ros2/rviz/blob/16ad728224246ac8361e7073e1c89baec5a0eaf1/rviz_ogre_vendor/CMakeLists.txt#L162

--- a/meta-ros-common/recipes-devtools/ogre/ogre_1.12.8.bb
+++ b/meta-ros-common/recipes-devtools/ogre/ogre_1.12.8.bb
@@ -18,7 +18,7 @@ inherit cmake features_check
 
 REQUIRED_DISTRO_FEATURES = "x11"
 
-DEPENDS = "zlib libx11 pugixml"
+DEPENDS = "zlib libx11 pugixml freetype"
 
 # extra flags from rviz-ogre-vendor ExternalProject_Add in:
 # https://github.com/ros2/rviz/blob/16ad728224246ac8361e7073e1c89baec5a0eaf1/rviz_ogre_vendor/CMakeLists.txt#L162

--- a/meta-ros2-foxy/recipes-bbappends/rviz/rviz-common_%.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/rviz/rviz-common_%.bbappend
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+# CMake Warning at /jenkins/mjansa/build/ros/ros2-foxy-dunfell/tmp-glibc/work/core2-64-oe-linux/rviz-common/8.2.0-1-r0/recipe-sysroot/usr/lib/cmake/Qt5/Qt5Config.cmake:7 (message):
+#   SkippingbecauseOE_QMAKE_PATH_EXTERNAL_HOST_BINSisnotdefined
+# ...
+# CMake Error at CMakeLists.txt:137 (qt5_wrap_cpp):
+#   Unknown CMake command "qt5_wrap_cpp".
+inherit ${@bb.utils.contains_any('ROS_WORLD_SKIP_GROUPS', ['qt5', 'pyqt5'], '', 'cmake_qt5', d)}

--- a/meta-ros2-foxy/recipes-bbappends/rviz/rviz-default-plugins_%.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/rviz/rviz-default-plugins_%.bbappend
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+# CMake Warning at /jenkins/mjansa/build/ros/ros2-foxy-dunfell/tmp-glibc/work/core2-64-oe-linux/rviz-default-plugins/8.2.0-1-r0/recipe-sysroot/usr/lib/cmake/Qt5/Qt5Config.cmake:7 (message):
+#   SkippingbecauseOE_QMAKE_PATH_EXTERNAL_HOST_BINSisnotdefined
+# ...
+# CMake Error at CMakeLists.txt:125 (qt5_wrap_cpp):
+#   Unknown CMake command "qt5_wrap_cpp".
+inherit ${@bb.utils.contains_any('ROS_WORLD_SKIP_GROUPS', ['qt5', 'pyqt5'], '', 'cmake_qt5', d)}

--- a/meta-ros2-foxy/recipes-bbappends/rviz/rviz-rendering_%.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/rviz/rviz-rendering_%.bbappend
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+# CMake Warning at /jenkins/mjansa/build/ros/ros2-foxy-dunfell/tmp-glibc/work/core2-64-oe-linux/rviz-rendering/8.2.0-1-r0/recipe-sysroot/usr/lib/cmake/Qt5/Qt5Config.cmake:7 (message):
+# SkippingbecauseOE_QMAKE_PATH_EXTERNAL_HOST_BINSisnotdefined
+# ...
+# CMake Error at CMakeLists.txt:65 (qt5_wrap_cpp):
+#   Unknown CMake command "qt5_wrap_cpp".
+inherit ${@bb.utils.contains_any('ROS_WORLD_SKIP_GROUPS', ['qt5', 'pyqt5'], '', 'cmake_qt5', d)}


### PR DESCRIPTION
https://github.com/ros/meta-ros/pull/813 cannot be tested in our builds, because it fails long before reaching slam-toolbox.

Our ROS DISTRO builds include x11 in DISTRO_FEATURES, but don't include meta-qt5.

Our webOS OSE builds on the other hand include meta-qt5, but without x11 in DISTRO_FEATURES.

So to at least start building slam-toolbox I had to add meta-qt5 in ROS builds, add opengl to DISTRO_FEATURES and then all rviz-* recipes slam-toolbox depends on are failing. This PR should fix at least some of them, but I wonder how https://github.com/ros/meta-ros/pull/813 was tested without these fixes (maybe they already exist elsewhere and just weren't ever submitted to us). @LewisLiuPub ?