### PR TITLE
[dunfell][gatesgarth][harknott][master] ogre

### DIFF
--- a/meta-ros-common/recipes-devtools/ogre/ogre_1.12.8.bb
+++ b/meta-ros-common/recipes-devtools/ogre/ogre_1.12.8.bb
@@ -18,7 +18,7 @@ inherit cmake features_check
 
 REQUIRED_DISTRO_FEATURES = "x11"
 
-DEPENDS = "zlib libx11 pugixml freetype virtual/libgl libglu"
+DEPENDS = "zlib libx11 pugixml freetype ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'virtual/libgl libglu', '', d)}"
 
 # extra flags from rviz-ogre-vendor ExternalProject_Add in:
 # https://github.com/ros2/rviz/blob/16ad728224246ac8361e7073e1c89baec5a0eaf1/rviz_ogre_vendor/CMakeLists.txt#L162


### PR DESCRIPTION
* fixes:
ERROR: Nothing PROVIDES 'virtual/libgl' (but ros2-foxy-dunfell/meta-ros/meta-ros-common/recipes-devtools/ogre/ogre_1.12.8.bb DEPENDS on or otherwise requires it)
mesa-gl PROVIDES virtual/libgl but was skipped: one of 'vulkan opengl' needs to be in DISTRO_FEATURES
ERROR: Nothing PROVIDES 'libglu' (but ros2-foxy-dunfell/meta-ros/meta-ros-common/recipes-devtools/ogre/ogre_1.12.8.bb DEPENDS on or otherwise requires it)
libglu was skipped: missing required distro feature 'opengl' (not in DISTRO_FEATURES)
ERROR: Nothing RPROVIDES 'ogre-dev' (but ros2-foxy-dunfell/meta-ros/meta-ros-common/recipes-devtools/ogre/ogre_1.12.8.bb RDEPENDS on or otherwise requires it)
No eligible RPROVIDERs exist for 'ogre-dev'
NOTE: Runtime target 'ogre-dev' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['ogre-dev']
ERROR: Nothing RPROVIDES 'ogre' (but ros2-foxy-dunfell/meta-ros/meta-ros-common/recipes-devtools/ogre/ogre_1.12.8.bb RDEPENDS on or otherwise requires it)
No eligible RPROVIDERs exist for 'ogre'
NOTE: Runtime target 'ogre' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['ogre']

Signed-off-by: Martin Jansa <martin.jansa@lge.com>