### PR TITLE
[dunfell][foxy] change SRC_URI for fmi-adapter and  fmilibrary-vendor

### DIFF
--- a/meta-ros2-foxy/generated-recipes/fmi-adapter-ros2/fmi-adapter_0.1.8-1.bb
+++ b/meta-ros2-foxy/generated-recipes/fmi-adapter-ros2/fmi-adapter_0.1.8-1.bb
@@ -62,11 +62,10 @@ DEPENDS += "${ROS_EXPORT_DEPENDS} ${ROS_BUILDTOOL_EXPORT_DEPENDS}"
 
 RDEPENDS_${PN} += "${ROS_EXEC_DEPENDS}"
 
-# matches with: https://github.com/boschresearch/fmi_adapter_ros2-release/archive/release/foxy/fmi_adapter/0.1.8-1.tar.gz
-ROS_BRANCH ?= "branch=release/foxy/fmi_adapter"
-SRC_URI = "git://github.com/boschresearch/fmi_adapter_ros2-release;${ROS_BRANCH};protocol=https"
-SRCREV = "074ff660c29b2114934f0c93b6f27d2459ad97ae"
-S = "${WORKDIR}/git"
+ROS_BRANCH ?= "branch=foxy"
+SRC_URI = "git://github.com/boschresearch/fmi_adapter;${ROS_BRANCH};protocol=https"
+SRCREV = "7dba74312ae6e582a02bdb307ff0f5be63364459"
+S = "${WORKDIR}/git/fmi_adapter"
 
 ROS_BUILD_TYPE = "ament_cmake"
 

--- a/meta-ros2-foxy/recipes-bbappends/fmilibrary-vendor/fmilibrary-vendor/0001-CMakeLists.txt-just-depend-on-system-fmilibrary-with.patch
+++ b/meta-ros2-foxy/recipes-bbappends/fmilibrary-vendor/fmilibrary-vendor/0001-CMakeLists.txt-just-depend-on-system-fmilibrary-with.patch
@@ -1,7 +1,7 @@
-From a2b01c8d9bd3e8f502dd96a51f8c0abbcf929559 Mon Sep 17 00:00:00 2001
+From b109f8fe500c4dd2630c881e41ba84608c1c1617 Mon Sep 17 00:00:00 2001
 From: Martin Jansa <martin.jansa@lge.com>
-Date: Fri, 29 Nov 2019 19:03:46 -0800
-Subject: [PATCH] CMakeLists.txt: just depend on system fmilibrary without
+Date: Mon, 5 Apr 2021 15:00:40 +0900
+Subject: [PATCH] CMakeLists.txt: just depend on system fmilibrary without 
  trying to build it
 
 * -DFMILIB_BUILD_TESTS=OFF is also needed when cross-compiling
@@ -10,28 +10,33 @@ Upstream-Status: Pending
 
 Signed-off-by: Martin Jansa <martin.jansa@lge.com>
 ---
- CMakeLists.txt | 32 ++++++++++++++++++++------------
- 1 file changed, 20 insertions(+), 12 deletions(-)
+ CMakeLists.txt | 36 +++++++++++++++++++-----------------
+ 1 file changed, 19 insertions(+), 17 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index adb4abf..31b3468 100644
+index df8d628..45c688f 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -3,19 +3,27 @@ project(fmilibrary_vendor)
+@@ -2,25 +2,27 @@ cmake_minimum_required(VERSION 3.5)
+ project(fmilibrary_vendor)
  
  find_package(ament_cmake REQUIRED)
- 
--include(ExternalProject)
--externalproject_add(FMILibraryProject
--  GIT_REPOSITORY https://github.com/modelon-community/fmi-library.git
--  GIT_TAG 2.1
--  TIMEOUT 60
--)
--externalproject_get_property(FMILibraryProject INSTALL_DIR)
--set(FMILibraryProject_INCLUDE_DIR "${INSTALL_DIR}/src/install/include")
--set(FMILibraryProject_LIB_DIR "${INSTALL_DIR}/src/install/lib")
 +find_package(fmilibrary)
  
+-include(ExternalProject)
+-set(fmilibrary_version 2.2.3)
+-externalproject_add(FMILibraryProject-${fmilibrary_version}
+-  GIT_REPOSITORY https://github.com/modelon-community/fmi-library.git
+-  GIT_TAG ${fmilibrary_version}
+-  GIT_CONFIG advice.detachedHead=false
+-  # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+-  UPDATE_COMMAND ""
+-  TIMEOUT 60
+-)
+-externalproject_get_property(FMILibraryProject-${fmilibrary_version} INSTALL_DIR)
+-set(FMILibraryProject_INCLUDE_DIR "${INSTALL_DIR}/src/install/include")
+-set(FMILibraryProject_LIB_DIR "${INSTALL_DIR}/src/install/lib")
+-
 -install(DIRECTORY ${FMILibraryProject_INCLUDE_DIR}/ DESTINATION include)
 -install(FILES ${FMILibraryProject_LIB_DIR}/libfmilib.a DESTINATION lib)
 -install(FILES ${FMILibraryProject_LIB_DIR}/libfmilib_shared.so DESTINATION lib)
@@ -47,13 +52,15 @@ index adb4abf..31b3468 100644
 +  externalproject_get_property(FMILibraryProject INSTALL_DIR)
 +  set(FMILibraryProject_INCLUDE_DIR "${INSTALL_DIR}/src/install/include")
 +  set(FMILibraryProject_LIB_DIR "${INSTALL_DIR}/src/install/lib")
-+
+ 
 +  install(DIRECTORY ${FMILibraryProject_INCLUDE_DIR}/ DESTINATION include)
 +  install(FILES ${FMILibraryProject_LIB_DIR}/libfmilib.a DESTINATION lib)
 +  install(FILES ${FMILibraryProject_LIB_DIR}/libfmilib_shared.so DESTINATION lib)
 +else()
 +  message(STATUS "Found fmilibrary ${fmilibrary_VERSION}")
 +endif()
- 
  ament_export_include_directories(include)
  ament_export_libraries(libfmilib.a libfmilib_shared.so)
+ ament_package()
+-- 
+2.17.1

--- a/meta-ros2-foxy/recipes-bbappends/fmilibrary-vendor/fmilibrary-vendor_0.2.0-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/fmilibrary-vendor/fmilibrary-vendor_0.2.0-1.bbappend
@@ -5,4 +5,11 @@ ROS_BUILD_DEPENDS += " \
 "
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+LIC_FILES_CHKSUM = "file://package.xml;beginline=9;endline=9;md5=665599198b8a9e42fd087c8d041ec61f"
+
+ROS_BRANCH = "branch=foxy"
+SRC_URI = "git://github.com/boschresearch/fmilibrary_vendor;${ROS_BRANCH};protocol=https"
+SRCREV = "7ad20fa47c86c522dfed7c9685555656bc718c68"
+
 SRC_URI += "file://0001-CMakeLists.txt-just-depend-on-system-fmilibrary-with.patch"


### PR DESCRIPTION
The fmi-adapter and fmilibrary-vendor repositories are removed in github.com/boschresearch.
These repo are changed fmi_adapter_ros2-release to  fmi_adapter  and fmilibrary_vendor-release to fmilibrary_vendor.
