### PR TITLE
[dashing][eloquent][foxy][dunfell][gatesgarth][hardknott][master] fmi-adapter{,-examples}: backport SRC_URI fix

### DIFF
--- a/meta-ros2-dashing/recipes-bbappends/fmi-adapter-ros2/fmi-adapter-examples_0.1.7-1.bbappend
+++ b/meta-ros2-dashing/recipes-bbappends/fmi-adapter-ros2/fmi-adapter-examples_0.1.7-1.bbappend
@@ -1,0 +1,4 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+# backport https://github.com/ros/rosdistro/commit/e27c2fdadc560e6ecf653d73d01d3cff10bda49e
+SRC_URI = "git://github.com/ros2-gbp/fmi_adapter-release;${ROS_BRANCH};protocol=https"

--- a/meta-ros2-dashing/recipes-bbappends/fmi-adapter-ros2/fmi-adapter_0.1.7-1.bbappend
+++ b/meta-ros2-dashing/recipes-bbappends/fmi-adapter-ros2/fmi-adapter_0.1.7-1.bbappend
@@ -1,0 +1,4 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+# backport https://github.com/ros/rosdistro/commit/e27c2fdadc560e6ecf653d73d01d3cff10bda49e
+SRC_URI = "git://github.com/ros2-gbp/fmi_adapter-release;${ROS_BRANCH};protocol=https"

--- a/meta-ros2-dashing/recipes-bbappends/fmilibrary-vendor/fmilibrary-vendor_0.2.0-1.bbappend
+++ b/meta-ros2-dashing/recipes-bbappends/fmilibrary-vendor/fmilibrary-vendor_0.2.0-1.bbappend
@@ -1,8 +1,13 @@
-# Copyright (c) 2019 LG Electronics, Inc.
+# Copyright (c) 2019-2021 LG Electronics, Inc.
 
 ROS_BUILD_DEPENDS += " \
     fmilibrary \
 "
+
+# backport https://github.com/ros/rosdistro/commit/2617ae2b86d9eacee6f7b6a66472255047da87ba
+SRC_URI = "git://github.com/ros2-gbp/fmilibrary_vendor-release;${ROS_BRANCH};protocol=https"
+# branches were recreated, the SRCREV exists, but isn't included in any branch
+ROS_BRANCH = "nobranch=1"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI += "file://0001-CMakeLists.txt-just-depend-on-system-fmilibrary-with.patch"

--- a/meta-ros2-eloquent/recipes-bbappends/fmi-adapter-ros2/fmi-adapter-examples_0.1.7-2.bbappend
+++ b/meta-ros2-eloquent/recipes-bbappends/fmi-adapter-ros2/fmi-adapter-examples_0.1.7-2.bbappend
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+# backport equivalent of following changes:
+# dashing: https://github.com/ros/rosdistro/commit/e27c2fdadc560e6ecf653d73d01d3cff10bda49e
+# foxy: https://github.com/ros/rosdistro/commit/ef8ab3a3d8ca3b9de81807050f22ec4a300fb6f2
+SRC_URI = "git://github.com/ros2-gbp/fmi_adapter-release;${ROS_BRANCH};protocol=https"

--- a/meta-ros2-eloquent/recipes-bbappends/fmi-adapter-ros2/fmi-adapter_0.1.7-2.bbappend
+++ b/meta-ros2-eloquent/recipes-bbappends/fmi-adapter-ros2/fmi-adapter_0.1.7-2.bbappend
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+# backport equivalent of following changes:
+# dashing: https://github.com/ros/rosdistro/commit/e27c2fdadc560e6ecf653d73d01d3cff10bda49e
+# foxy: https://github.com/ros/rosdistro/commit/ef8ab3a3d8ca3b9de81807050f22ec4a300fb6f2
+SRC_URI = "git://github.com/ros2-gbp/fmi_adapter-release;${ROS_BRANCH};protocol=https"

--- a/meta-ros2-eloquent/recipes-bbappends/fmilibrary-vendor/fmilibrary-vendor_0.2.0-1.bbappend
+++ b/meta-ros2-eloquent/recipes-bbappends/fmilibrary-vendor/fmilibrary-vendor_0.2.0-1.bbappend
@@ -1,8 +1,15 @@
-# Copyright (c) 2019 LG Electronics, Inc.
+# Copyright (c) 2019-2021 LG Electronics, Inc.
 
 ROS_BUILD_DEPENDS += " \
     fmilibrary \
 "
+
+# backport equivalent of following changes:
+# foxy: https://github.com/ros/rosdistro/commit/d6f5a0ca09f6d15c4e1ae4beb85b25447355c120
+# dashing: https://github.com/ros/rosdistro/commit/2617ae2b86d9eacee6f7b6a66472255047da87ba
+SRC_URI = "git://github.com/ros2-gbp/fmilibrary_vendor-release;${ROS_BRANCH};protocol=https"
+# branches were recreated, the SRCREV exists, but isn't included in any branch
+ROS_BRANCH = "nobranch=1"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI += "file://0001-CMakeLists.txt-just-depend-on-system-fmilibrary-with.patch"

--- a/meta-ros2-foxy/recipes-bbappends/fmi-adapter-ros2/fmi-adapter-examples_0.1.8-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/fmi-adapter-ros2/fmi-adapter-examples_0.1.8-1.bbappend
@@ -1,0 +1,4 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+# backport https://github.com/ros/rosdistro/commit/ef8ab3a3d8ca3b9de81807050f22ec4a300fb6f2
+SRC_URI = "git://github.com/ros2-gbp/fmi_adapter-release;${ROS_BRANCH};protocol=https"

--- a/meta-ros2-foxy/recipes-bbappends/fmi-adapter-ros2/fmi-adapter_0.1.8-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/fmi-adapter-ros2/fmi-adapter_0.1.8-1.bbappend
@@ -1,0 +1,4 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+# backport https://github.com/ros/rosdistro/commit/ef8ab3a3d8ca3b9de81807050f22ec4a300fb6f2
+SRC_URI = "git://github.com/ros2-gbp/fmi_adapter-release;${ROS_BRANCH};protocol=https"

--- a/meta-ros2-foxy/recipes-bbappends/fmilibrary-vendor/fmilibrary-vendor_0.2.0-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/fmilibrary-vendor/fmilibrary-vendor_0.2.0-1.bbappend
@@ -1,8 +1,13 @@
-# Copyright (c) 2019 LG Electronics, Inc.
+# Copyright (c) 2019-2021 LG Electronics, Inc.
 
 ROS_BUILD_DEPENDS += " \
     fmilibrary \
 "
+
+# backport https://github.com/ros/rosdistro/commit/d6f5a0ca09f6d15c4e1ae4beb85b25447355c120
+SRC_URI = "git://github.com/ros2-gbp/fmilibrary_vendor-release;${ROS_BRANCH};protocol=https"
+# branches were recreated, the SRCREV exists, but is included only in release/rolling/fmilibrary_vendor branch now
+ROS_BRANCH = "nobranch=1"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI += "file://0001-CMakeLists.txt-just-depend-on-system-fmilibrary-with.patch"


### PR DESCRIPTION
rolling needs the same fix, but because fmi-adapter is upgraded in https://github.com/ros/meta-ros/pull/806 I'll add the fix there.