### PR TITLE
[dunfell] {backports-gatesgarth} python3-pybind11=v2.5.0

### DIFF
--- a/meta-ros-backports-gatesgarth/recipes-devtools/python/python3-pybind11/0001-Do-not-check-pointer-size-when-cross-compiling.patch
+++ b/meta-ros-backports-gatesgarth/recipes-devtools/python/python3-pybind11/0001-Do-not-check-pointer-size-when-cross-compiling.patch
@@ -1,0 +1,32 @@
+From 3abfa65517959ad279481021fafefba28f955e76 Mon Sep 17 00:00:00 2001
+From: Philip Balister <philip@balister.org>
+Date: Fri, 10 Jul 2020 10:14:59 -0400
+Subject: [PATCH] Do not check pointer size when cross compiling.
+
+It is reasonable to build for 32 machine on a 64 bit build machine. Prevents:
+| CMake Error at tools/FindPythonLibsNew.cmake:127 (message):
+|   Python config failure: Python is 64-bit, chosen compiler is 32-bit
+
+Upstream-Status: Pending
+
+Signed-off-by: Philip Balister <philip@balister.org>
+---
+ tools/FindPythonLibsNew.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/FindPythonLibsNew.cmake b/tools/FindPythonLibsNew.cmake
+index d0c8fa2..8479e70 100644
+--- a/tools/FindPythonLibsNew.cmake
++++ b/tools/FindPythonLibsNew.cmake
+@@ -123,7 +123,7 @@ list(GET _PYTHON_VALUES 9 PYTHON_MULTIARCH)
+ 
+ # Make sure the Python has the same pointer-size as the chosen compiler
+ # Skip if CMAKE_SIZEOF_VOID_P is not defined
+-if(CMAKE_SIZEOF_VOID_P AND (NOT "${PYTHON_SIZEOF_VOID_P}" STREQUAL "${CMAKE_SIZEOF_VOID_P}"))
++if((NOT CMAKE_CROSSCOMPILING) AND CMAKE_SIZEOF_VOID_P AND (NOT "${PYTHON_SIZEOF_VOID_P}" STREQUAL "${CMAKE_SIZEOF_VOID_P}"))
+     if(PythonLibsNew_FIND_REQUIRED)
+         math(EXPR _PYTHON_BITS "${PYTHON_SIZEOF_VOID_P} * 8")
+         math(EXPR _CMAKE_BITS "${CMAKE_SIZEOF_VOID_P} * 8")
+-- 
+2.25.4
+

--- a/meta-ros-backports-gatesgarth/recipes-devtools/python/python3-pybind11/0001-Do-not-strip-binaries.patch
+++ b/meta-ros-backports-gatesgarth/recipes-devtools/python/python3-pybind11/0001-Do-not-strip-binaries.patch
@@ -1,0 +1,41 @@
+From 918f3ef01c7a67f3beb67307966698474f144581 Mon Sep 17 00:00:00 2001
+From: Philip Balister <philip@balister.org>
+Date: Wed, 8 Jul 2020 09:41:43 -0400
+Subject: [PATCH] Do not strip binaries.
+
+ * OpenEmbedded strips them after creating debug packages.
+
+Upstream-Status: Pending
+
+Signed-off-by: Philip Balister <philip@balister.org>
+---
+ tools/pybind11Tools.cmake | 13 -------------
+ 1 file changed, 13 deletions(-)
+
+diff --git a/tools/pybind11Tools.cmake b/tools/pybind11Tools.cmake
+index a3603ab..b4c8f63 100644
+--- a/tools/pybind11Tools.cmake
++++ b/tools/pybind11Tools.cmake
+@@ -230,19 +230,6 @@ function(pybind11_add_module target_name)
+ 
+   _pybind11_add_lto_flags(${target_name} ${ARG_THIN_LTO})
+ 
+-  if (NOT MSVC AND NOT ${CMAKE_BUILD_TYPE} MATCHES Debug|RelWithDebInfo)
+-    # Strip unnecessary sections of the binary on Linux/Mac OS
+-    if(CMAKE_STRIP)
+-      if(APPLE)
+-        add_custom_command(TARGET ${target_name} POST_BUILD
+-                           COMMAND ${CMAKE_STRIP} -x $<TARGET_FILE:${target_name}>)
+-      else()
+-        add_custom_command(TARGET ${target_name} POST_BUILD
+-                           COMMAND ${CMAKE_STRIP} $<TARGET_FILE:${target_name}>)
+-      endif()
+-    endif()
+-  endif()
+-
+   if(MSVC)
+     # /MP enables multithreaded builds (relevant when there are many files), /bigobj is
+     # needed for bigger binding projects due to the limit to 64k addressable sections
+-- 
+2.25.4
+

--- a/meta-ros-backports-gatesgarth/recipes-devtools/python/python3-pybind11_2.5.0.bb
+++ b/meta-ros-backports-gatesgarth/recipes-devtools/python/python3-pybind11_2.5.0.bb
@@ -1,0 +1,36 @@
+SUMMARY = "Seamless operability between C++11 and Python"
+HOMEPAGE = "https://github.com/wjakob/pybind11"
+LICENSE = "BSD-2-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=beb87117af69fd10fbf9fb14c22a2e62"
+
+DEPENDS = "boost"
+
+SRC_URI = "git://github.com/pybind/pybind11.git \
+           file://0001-Do-not-strip-binaries.patch \
+           file://0001-Do-not-check-pointer-size-when-cross-compiling.patch \
+          "
+SRCREV = "3b1dbebabc801c9cf6f0953a4c20b904d444f879"
+
+S = "${WORKDIR}/git"
+
+BBCLASSEXTEND = "native"
+
+EXTRA_OECMAKE =  "-DPYBIND11_TEST=OFF"
+
+inherit cmake setuptools3 python3native
+
+do_configure() {
+	cmake_do_configure
+}
+
+do_compile() {
+	distutils3_do_compile
+	cmake_do_compile
+}
+
+do_install() {
+	distutils3_do_install
+	cmake_do_install
+}
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
* backport never version from gatesgarth, because 2.4.3 in dunfell
  doesn't provide pybind11Config.cmake used by rosbag2-py

python3-pybind11$ diff -rq  */image
Only in 2.5.0-r0-gatesgarth/image/usr/include: pybind11
Files 2.4.3-r0/image/usr/include/python3.8/pybind11/buffer_info.h and 2.5.0-r0-gatesgarth/image/usr/include/python3.8/pybind11/buffer_info.h differ
Files 2.4.3-r0/image/usr/include/python3.8/pybind11/cast.h and 2.5.0-r0-gatesgarth/image/usr/include/python3.8/pybind11/cast.h differ
Files 2.4.3-r0/image/usr/include/python3.8/pybind11/detail/class.h and 2.5.0-r0-gatesgarth/image/usr/include/python3.8/pybind11/detail/class.h differ
Files 2.4.3-r0/image/usr/include/python3.8/pybind11/detail/common.h and 2.5.0-r0-gatesgarth/image/usr/include/python3.8/pybind11/detail/common.h differ
Files 2.4.3-r0/image/usr/include/python3.8/pybind11/detail/internals.h and 2.5.0-r0-gatesgarth/image/usr/include/python3.8/pybind11/detail/internals.h differ
Files 2.4.3-r0/image/usr/include/python3.8/pybind11/embed.h and 2.5.0-r0-gatesgarth/image/usr/include/python3.8/pybind11/embed.h differ
Files 2.4.3-r0/image/usr/include/python3.8/pybind11/pybind11.h and 2.5.0-r0-gatesgarth/image/usr/include/python3.8/pybind11/pybind11.h differ
Files 2.4.3-r0/image/usr/include/python3.8/pybind11/pytypes.h and 2.5.0-r0-gatesgarth/image/usr/include/python3.8/pybind11/pytypes.h differ
Files 2.4.3-r0/image/usr/include/python3.8/pybind11/stl_bind.h and 2.5.0-r0-gatesgarth/image/usr/include/python3.8/pybind11/stl_bind.h differ
Files 2.4.3-r0/image/usr/lib/python3.8/site-packages/pybind11/__init__.py and 2.5.0-r0-gatesgarth/image/usr/lib/python3.8/site-packages/pybind11/__init__.py differ
Files 2.4.3-r0/image/usr/lib/python3.8/site-packages/pybind11/__main__.py and 2.5.0-r0-gatesgarth/image/usr/lib/python3.8/site-packages/pybind11/__main__.py differ
Files 2.4.3-r0/image/usr/lib/python3.8/site-packages/pybind11/__pycache__/__init__.cpython-38.pyc and 2.5.0-r0-gatesgarth/image/usr/lib/python3.8/site-packages/pybind11/__pycache__/__init__.cpython-38.pyc differ
Files 2.4.3-r0/image/usr/lib/python3.8/site-packages/pybind11/__pycache__/__main__.cpython-38.pyc and 2.5.0-r0-gatesgarth/image/usr/lib/python3.8/site-packages/pybind11/__pycache__/__main__.cpython-38.pyc differ
Files 2.4.3-r0/image/usr/lib/python3.8/site-packages/pybind11/__pycache__/_version.cpython-38.pyc and 2.5.0-r0-gatesgarth/image/usr/lib/python3.8/site-packages/pybind11/__pycache__/_version.cpython-38.pyc differ
Files 2.4.3-r0/image/usr/lib/python3.8/site-packages/pybind11/_version.py and 2.5.0-r0-gatesgarth/image/usr/lib/python3.8/site-packages/pybind11/_version.py differ
Only in 2.5.0-r0-gatesgarth/image/usr/lib/python3.8/site-packages/pybind11: include
Only in 2.4.3-r0/image/usr/lib/python3.8/site-packages: pybind11-2.4.3-py3.8.egg-info
Only in 2.5.0-r0-gatesgarth/image/usr/lib/python3.8/site-packages: pybind11-2.5.0-py3.8.egg-info
Only in 2.5.0-r0-gatesgarth/image/usr: share

python3-pybind11$ find 2.5.0-r0-gatesgarth/image/usr/share/cmake/pybind11/
2.5.0-r0-gatesgarth/image/usr/share/cmake/pybind11/
2.5.0-r0-gatesgarth/image/usr/share/cmake/pybind11/pybind11Tools.cmake
2.5.0-r0-gatesgarth/image/usr/share/cmake/pybind11/FindPythonLibsNew.cmake
2.5.0-r0-gatesgarth/image/usr/share/cmake/pybind11/pybind11Targets.cmake
2.5.0-r0-gatesgarth/image/usr/share/cmake/pybind11/pybind11ConfigVersion.cmake
2.5.0-r0-gatesgarth/image/usr/share/cmake/pybind11/pybind11Config.cmake

without this rosbag2-py fails with:

-- Using PYTHON_LIBRARIES: ros2-rolling-dunfell/ros2-rolling-dunfell/tmp-glibc/work/aarch64-oe-linux/rosbag2-py/0.6.0-1-r0/recipe-sysroot/usr/lib/libpython3.8.so
-- Found PythonExtra: .so
CMake Error at CMakeLists.txt:34 (find_package):
  By not providing "Findpybind11.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "pybind11",
  but CMake did not find one.

  Could not find a package configuration file provided by "pybind11" with any
  of the following names:

    pybind11Config.cmake
    pybind11-config.cmake

  Add the installation prefix of "pybind11" to CMAKE_PREFIX_PATH or set
  "pybind11_DIR" to a directory containing one of the above files.  If
  "pybind11" provides a separate development package or SDK, be sure it has
  been installed.

-- Configuring incomplete, errors occurred!

Signed-off-by: Martin Jansa <martin.jansa@lge.com>