### PR TITLE
[dunfell][gatesgarth][hardknott][master] {foxy} rosbag2-compression: fix issue with zstd in rosbag2-compression 

### DIFF
--- a/meta-ros2-foxy/recipes-bbappends/rosbag2/rosbag2-compression/0002-CMakeLists.txt-link-against-zstd.patch
+++ b/meta-ros2-foxy/recipes-bbappends/rosbag2/rosbag2-compression/0002-CMakeLists.txt-link-against-zstd.patch
@@ -1,0 +1,30 @@
+From beb44ee0be81f4dd04083a0c46ddacbac71a73f9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Erik=20Bot=C3=B6?= <erik.boto@gmail.com>
+Date: Thu, 29 Apr 2021 13:08:49 +0200
+Subject: [PATCH] CMakeLists.txt: link against zstd
+
+Fix so that librosbag2_compression_zstd.so is linking to libzstd, to fix
+issue with unresolved symbol when using zstd compression.
+
+Upstream-Status: Pending
+
+Signed-off-by: Erik Botö <erik.boto@gmail.com>
+---
+ CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5db06ceb..ac2b61f5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -46,6 +46,7 @@ ament_target_dependencies(${PROJECT_NAME}_zstd
+ target_compile_definitions(${PROJECT_NAME}_zstd
+   PRIVATE
+   ROSBAG2_COMPRESSION_BUILDING_DLL)
++target_link_libraries(${PROJECT_NAME}_zstd ${ZSTD_LIBRARIES})
+ 
+ add_library(${PROJECT_NAME}
+   SHARED
+-- 
+2.25.1
+

--- a/meta-ros2-foxy/recipes-bbappends/rosbag2/rosbag2-compression_0.3.7-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/rosbag2/rosbag2-compression_0.3.7-1.bbappend
@@ -1,7 +1,10 @@
 # Copyright (c) 2020 LG Electronics, Inc.
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
-SRC_URI += "file://0001-CMakeLists.txt-drop-dependency-on-zstd_vendor.patch"
+SRC_URI += " \
+    file://0001-CMakeLists.txt-drop-dependency-on-zstd_vendor.patch \
+    file://0002-CMakeLists.txt-link-against-zstd.patch \
+"
 
 # PN package in zstd-vendor is empty and not created, remove runtime dependency on it
 ROS_EXEC_DEPENDS_remove = "zstd-vendor"


### PR DESCRIPTION
Fixes this issue:

```
# ros2 bag record -a --compression-mode file --compression-format zstd
Traceback (most recent call last):
  File "/usr/bin/ros2", line 11, in <module>
    load_entry_point('ros2cli==0.9.9', 'console_scripts', 'ros2')()
  File "/usr/lib/python3.8/site-packages/ros2cli/cli.py", line 67, in main
    rc = extension.main(parser=parser, args=args)
  File "/usr/lib/python3.8/site-packages/ros2bag/command/bag.py", line 38, in main
    return extension.main(args=args)
  File "/usr/lib/python3.8/site-packages/ros2bag/verb/record.py", line 119, in main
    from rosbag2_transport import rosbag2_transport_py
  File "/usr/lib/python3.8/site-packages/rosbag2_transport/__init__.py", line 17, in <module>
    rosbag2_transport_py = import_c_library('._rosbag2_transport_py', package='rosbag2_transport')
  File "/usr/lib/python3.8/site-packages/rpyutils/import_c_library.py", line 39, in import_c_library
    return importlib.import_module(name, package=package)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ImportError: /usr/lib/librosbag2_compression_zstd.so: undefined symbol: ZSTD_getFrameContentSize
The C extension '/usr/lib/python3.8/site-packages/rosbag2_transport/_rosbag2_transport_py.cpython-38-arm-linux-gnueabi.so' failed to be imported while being present on the system. Please refer to 'https://index.ros.org/doc/ros2/Troubleshooting/Installation-Troubleshooting/#import-failing-even-with-library-present-on-the-system' for possible solutions
```