### PR TITLE
[dunfell][gatesgarth][hardknott][honister] google-benchmark: use "main" branch

### DIFF
--- a/meta-ros2/recipes-benchmark/google-benchmark/google-benchmark_git.bb
+++ b/meta-ros2/recipes-benchmark/google-benchmark/google-benchmark_git.bb
@@ -10,7 +10,7 @@ PV = "1.5.1+git${SRCPV}"
 
 # matches with tag 1.5.1
 SRCREV = "8039b4030795b1c9b8cedb78e3a2a6fb89574b6e"
-SRC_URI = "git://github.com/google/benchmark"
+SRC_URI = "git://github.com/google/benchmark;branch=main"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Benchmark repository master branch has been renamed from "master" to "main".