### PR TITLE
[dunfell][gatesgarth][hardknott][honister] {galactic} rclpy: inherit python3targetconfig

### DIFF
--- a/meta-ros2-galactic/recipes-bbappends/rclpy/rclpy_1.9.0-1.bbappend
+++ b/meta-ros2-galactic/recipes-bbappends/rclpy/rclpy_1.9.0-1.bbappend
@@ -1,0 +1,3 @@
+# Copyright (c) 2021 LG Electronics, Inc.
+
+inherit python3targetconfig


### PR DESCRIPTION
* fixes PYTHON_MODULE_EXTENSION detection by
  rclpy/1.9.0-1-r0/recipe-sysroot/usr/share/cmake/pybind11/pybind11NewTools.cmak
  without this fix, it will use host's architecture, e.g.:
  PYTHON_MODULE_EXTENSION:INTERNAL=.cpython-39-x86_64-linux-gnu.so
  while we need target architecture, e.g.:
  PYTHON_MODULE_EXTENSION:INTERNAL=.cpython-39-arm-linux-gnueabi.so
  when building rclpy for qemuarm

* fixes https://github.com/ros/meta-ros/issues/885