### PR TITLE
[honister] meta-ros-common: ROS_OE_RELEASE_SERIES: switch from hardknott to honister

### DIFF
--- a/meta-ros-common/conf/ros-distro/ros-distro.conf
+++ b/meta-ros-common/conf/ros-distro/ros-distro.conf
@@ -14,7 +14,7 @@ ROS_DISTRO_COMPAT = "melodic dashing eloquent"
 
 # This variable is updated with the new release series as the first commit to [master] after the branch for the current release
 # series is created.
-ROS_OE_RELEASE_SERIES = "hardknott"
+ROS_OE_RELEASE_SERIES = "honister"
 
 # "1" or "2"
 ROS_DISTRO_METADATA_VERSION_MAJOR = "${ROS_VERSION}"


### PR DESCRIPTION
* follow oe-core:
  https://git.openembedded.org/openembedded-core/commit/?h=master-next&id=72c04cb3ca78208a135275d6dd43ad500b663cb5
