### PR TITLE
[dunfell][gatesgarth][hardknott][honister] {galactic} apriltag: inherit python3targetconfig

### DIFF
--- a/meta-ros2-galactic/recipes-bbappends/apriltag/apriltag/0001-CMakeLists.txt-allow-to-set-PY_DEST.patch
+++ b/meta-ros2-galactic/recipes-bbappends/apriltag/apriltag/0001-CMakeLists.txt-allow-to-set-PY_DEST.patch
@@ -1,0 +1,55 @@
+From 7ae39b993cdff4f5bca374cea8c44383a2d15de5 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Mon, 6 Sep 2021 12:02:27 +0000
+Subject: [PATCH] CMakeLists.txt: allow to set PY_DEST
+
+* with OE we want to set it to PYTHON_SITEPACKAGES_DIR, because even with
+  python3targetconfig the site module returns paths to native sysroot:
+
+  apriltag/3.1.5-1-r0/git$ python3 -m site
+  sys.path = [
+      '/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git',
+      '/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/python39.zip',
+      '/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/python3.9',
+      '/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/python3.9/lib-dynload',
+      '/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/python3.9/site-packages',
+  ]
+  USER_BASE: '/home/mjansa/.local' (exists)
+  USER_SITE: '/home/mjansa/.local/lib/python3.9/site-packages' (exists)
+  ENABLE_USER_SITE: False
+
+  apriltag/3.1.5-1-r0/git$ python3 -c "import site; print(site.getsitepackages()[0])"
+  /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/python3.9/site-packages
+
+  apriltag/3.1.5-1-r0/git$ export _PYTHON_SYSCONFIGDATA_NAME=_sysconfigdata
+
+  apriltag/3.1.5-1-r0/git$ python3 -c "import site; print(site.getsitepackages()[0])"
+  /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/python3.9/site-packages
+
+* and currently used --user-site is even worse:
+  apriltag/3.1.5-1-r0/git$ python3 -m site --user-site
+  /home/mjansa/.local/lib/python3.6/site-packages
+
+Upstream-Status: Pending
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ CMakeLists.txt | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index edde563..0d6c5ef 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -134,8 +134,10 @@ if (NOT Python3_NOT_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND AND BUILD
+     add_custom_target(apriltag_python ALL
+         DEPENDS apriltag${PY_EXT_SUFFIX})
+ 
+-execute_process(COMMAND python3 -m site --user-site OUTPUT_VARIABLE PY_DEST)
+-string(STRIP ${PY_DEST} PY_DEST)
++if (NOT PY_DEST)
++  execute_process(COMMAND python3 -m site --user-site OUTPUT_VARIABLE PY_DEST)
++  string(STRIP ${PY_DEST} PY_DEST)
++endif (NOT PY_DEST)
+ install(FILES ${PROJECT_BINARY_DIR}/apriltag${PY_EXT_SUFFIX} DESTINATION ${PY_DEST})
+ endif (NOT Python3_NOT_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND AND BUILD_PYTHON_WRAPPER)
+ 

--- a/meta-ros2-galactic/recipes-bbappends/apriltag/apriltag_%.bbappend
+++ b/meta-ros2-galactic/recipes-bbappends/apriltag/apriltag_%.bbappend
@@ -1,3 +1,0 @@
-# Copyright (c) 2020 LG Electronics, Inc.
-
-inherit ros_insane_dev_so

--- a/meta-ros2-galactic/recipes-bbappends/apriltag/apriltag_3.1.5-1.bbappend
+++ b/meta-ros2-galactic/recipes-bbappends/apriltag/apriltag_3.1.5-1.bbappend
@@ -1,0 +1,11 @@
+# Copyright (c) 2020-2021 LG Electronics, Inc.
+
+inherit ros_insane_dev_so python3targetconfig
+
+DEPENDS += "python3-numpy-native"
+
+EXTRA_OECMAKE += "-DPY_DEST=${PYTHON_SITEPACKAGES_DIR}"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+SRC_URI += " \
+    file://0001-CMakeLists.txt-allow-to-set-PY_DEST.patch \
+"


### PR DESCRIPTION
* inherit python3native as do_configure calls python3 to figure out CFLAGS,
  which will unfortunately contain e.g. -I/usr/include/python3.6m from host,
  which is obviously wrong for cross-compilation:

   Called from: [1]     /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt
/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt(110):  execute_process(COMMAND which python3 OUTPUT_QUIET RESULT_VARIABLE Python3_NOT_FOUND )
   Called from: [1]     /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt
/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt(111):  execute_process(COMMAND python3 -c import numpy RESULT_VARIABLE Numpy_NOT_FOUND )
   Called from: [1]     /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt
/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt(114):  if(NOT Python3_NOT_FOUND AND NOT Numpy_NOT_FOUND AND PYTHONLIBS_FOUND AND BUILD_PYTHON_WRAPPER )
   Called from: [1]     /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt
/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt(116):  execute_process(COMMAND python3 /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/python_build_flags.py OUTPUT_VARIABLE PY_OUT )
   Called from: [1]     /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt
/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt(117):  set(PY_VARS CFLAGS LDFLAGS LINKER EXT_SUFFIX )
   Called from: [1]     /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt
/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/CMakeLists.txt(118):  cmake_parse_arguments(PY  CFLAGS;LDFLAGS;LINKER;EXT_SUFFIX  CFLAGS;-Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -flto -fuse-linker-plugin -ffat-lto-objects -fPIC -I/usr/include/python3.6m -I/usr/lib/python3/dist-packages/numpy/core/include -Wno-strict-prototypes;LINKER;x86_64-linux-gnu-gcc;LDFLAGS;-pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -lpython3.6m -Wl,-Bsymbolic-functions  -Wl,-z,relro;EXT_SUFFIX;.cpython-36m-x86_64-linux-gnu.so; )

* leading to:
FAILED: apriltag_pywrap.o
cd /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/build && /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/aarch64-oe-linux-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -flto -fuse-linker-plugin -ffat-lto-objects -fPIC -I/usr/include/python3.6m -I/usr/lib/python3/dist-packages/numpy/core/include -Wno-strict-prototypes -I/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/build -c -o apriltag_pywrap.o /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/apriltag_pywrap.c
cc1: warning: include location "/usr/include/python3.6m" is unsafe for cross-compilation [-Wpoison-system-directories]
In file included from /usr/include/python3.6m/Python.h:8,
                 from /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/apriltag_pywrap.c:4:
/usr/include/python3.6m/pyconfig.h:9:12: fatal error: aarch64-linux-gnu/python3.6m/pyconfig.h: No such file or directory
    9 | #  include <aarch64-linux-gnu/python3.6m/pyconfig.h>
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.

* with python3native the values are better:
CFLAGS;-Wno-unused-result -Wsign-compare -DNDEBUG -g -Wall -isystem/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/include -pipe -isystem/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/include -pipe -fPIC -I/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/include/python3.9 -I/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/python3.9/site-packages/numpy/core/include -Wno-strict-prototypes;LINKER;gcc;LDFLAGS;-pthread -shared -L/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib -L/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib -Wl,--enable-new-dtags -Wl,-rpath-link,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib -Wl,-rpath-link,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib -Wl,-rpath,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib -Wl,-rpath,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/jenkins/home/anaconda/ros2-eloquent-hardknott/tmp-glibc/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 -L/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib -L/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib -Wl,--enable-new-dtags -Wl,-rpath-link,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib -Wl,-rpath-link,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib -Wl,-rpath,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib -Wl,-rpath,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/jenkins/home/anaconda/ros2-eloquent-hardknott/tmp-glibc/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 -L. -lpython3.9 -L/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib                         -L/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib                         -Wl,--enable-new-dtags                         -Wl,-rpath-link,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath-link,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib                         -Wl,-rpath,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib                         -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/jenkins/home/anaconda/ros2-eloquent-hardknott/tmp-glibc/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 -L/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib                         -L/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib                         -Wl,--enable-new-dtags                         -Wl,-rpath-link,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath-link,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib                         -Wl,-rpath,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib                         -Wl,-rpath,/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/lib                         -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/jenkins/home/anaconda/ros2-eloquent-hardknott/tmp-glibc/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2;EXT_SUFFIX;.cpython-39-x86_64-linux-gnu.so;

* but still using configuration for native not target python3, inherit python3targetconfig with following values:
CFLAGS;-march=armv8-a+crc+crypto --sysroot=/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot -Wno-unused-result -Wsign-compare -DNDEBUG -g -Wall -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=/jenkins/home/anaconda/ros2-eloquent-hardknott/tmp-glibc/work/cortexa72-oe-linux/python3/3.9.5-r0=/usr/src/debug/python3/3.9.5-r0 -fdebug-prefix-map=/jenkins/home/anaconda/ros2-eloquent-hardknott/tmp-glibc/work/cortexa72-oe-linux/python3/3.9.5-r0=/usr/src/debug/python3/3.9.5-r0 -fdebug-prefix-map=/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot= -fdebug-prefix-map=/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native= -pipe -g -feliminate-unused-debug-types -fmacro-prefix-map=/jenkins/home/anaconda/ros2-eloquent-hardknott/tmp-glibc/work/cortexa72-oe-linux/python3/3.9.5-r0=/usr/src/debug/python3/3.9.5-r0 -fdebug-prefix-map=/jenkins/home/anaconda/ros2-eloquent-hardknott/tmp-glibc/work/cortexa72-oe-linux/python3/3.9.5-r0=/usr/src/debug/python3/3.9.5-r0 -fdebug-prefix-map=/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot= -fdebug-prefix-map=/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native= -fPIC -I/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot/usr/include/python3.9 -I/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/python3.9/site-packages/numpy/core/include -Wno-strict-prototypes;LINKER;aarch64-oe-linux-gcc;LDFLAGS;-mcpu=cortex-a72 -march=armv8-a+crc+crypto --sysroot=/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot -shared -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -L/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -L. -lpython3.9 -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -L/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed;EXT_SUFFIX;.cpython-39-aarch64-linux-gnu.so;

* then add python3-numpy-native to fix:

-- Found PythonLibs: /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot/usr/lib/libpython3.so (found version "3.9.5")
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'numpy'

shown only after adding python3native

* then change python3native to python3target config to fix:
| FAILED: apriltag_pywrap.o
| cd /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/build && /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/bin/aarch64-oe-linux/aarch64-oe-linux-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -Wall -isystem/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/include -pipe -isystem/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/include -pipe -fPIC -I/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/include/python3.9 -I/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/python3.9/site-packages/numpy/core/include -Wno-strict-prototypes -I/jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/build -c -o apriltag_pywrap.o /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/apriltag_pywrap.c
| In file included from /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/aarch64-oe-linux/gcc/aarch64-oe-linux/10.2.0/include-fixed/syslimits.h:7,
|                  from /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/aarch64-oe-linux/gcc/aarch64-oe-linux/10.2.0/include-fixed/limits.h:34,
|                  from /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/include/python3.9/Python.h:11,
|                  from /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/apriltag_pywrap.c:4:
| /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/lib/aarch64-oe-linux/gcc/aarch64-oe-linux/10.2.0/include-fixed/limits.h:195:61: error: no include path in which to search for limits.h
|   195 | #include_next <limits.h>  /* recurse down to the real one */
|       |                                                             ^
| In file included from /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/git/apriltag_pywrap.c:4:
| /jenkins/mjansa/build/ros/ros2-galactic-hardknott/tmp-glibc/work/cortexa72-oe-linux/apriltag/3.1.5-1-r0/recipe-sysroot-native/usr/include/python3.9/Python.h:25:10: fatal error: stdio.h: No such file or directory
|    25 | #include <stdio.h>
|       |          ^~~~~~~~~
| compilation terminated.

* and now it installs in wrong destination:
ERROR: apriltag-3.1.5-1-r0 do_package: QA Issue: apriltag: Files/directories were installed but not shipped in any package:
  /home
  /home/mjansa
  /home/mjansa/.local
  /home/mjansa/.local/lib
  /home/mjansa/.local/lib/python3.9
  /home/mjansa/.local/lib/python3.9/site-packages
  /home/mjansa/.local/lib/python3.9/site-packages/apriltag.cpython-39-aarch64-linux-gnu.so
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
apriltag: 7 installed and not shipped files. [installed-vs-shipped]

because CMakeLists.txt uses:
  apriltag/3.1.5-1-r0/git$ python3 -m site --user-site OUTPUT_VARIABLE PY_DEST
  /home/mjansa/.local/lib/python3.6/site-packages

  add a patch to allow setting PY_DEST from OE recipe

Signed-off-by: Martin Jansa <martin.jansa@lge.com>