### PR TITLE
[dunfell][gatesgarth][hardknott][honister][kirkstone] ros_recipe_now_generated.bbclass: fix vars_from_file() call

### DIFF
--- a/meta-ros-common/classes/ros_recipe_now_generated.bbclass
+++ b/meta-ros-common/classes/ros_recipe_now_generated.bbclass
@@ -4,7 +4,7 @@
 # between multiple recipes.
 
 def ros_recipe_now_generated__get_suffix(d):
-    pn = bb.parse.BBHandler.vars_from_file(d.getVar('FILE', False),d)[0] or 'defaultpkgname'
+    pn = bb.parse.vars_from_file(d.getVar('FILE', False),d)[0] or 'defaultpkgname'
     return bb.utils.contains('ROS_SUPERFLORE_GENERATED_RECIPES', pn, '-notgenerated', '', d)
 
 PN:append = "${@ros_recipe_now_generated__get_suffix(d)}"


### PR DESCRIPTION
bitbake-1.52 dropped the import from BBHandler in:
https://git.openembedded.org/bitbake/commit/?id=aaa5292ef96ea27f505bc5c5a4b1eb4f497ed061

and now meta-ros1 DISTROs (this bbclass is used only by urdfdom, urdfdom-headers recipes used by ROS1) fail with:

Parsing recipes...ERROR: ExpansionError during parsing /jenkins/home/anaconda/ros1-noetic-honister/meta-ros/meta-ros1/recipes-extended/urdfdom-headers/urdfdom-headers_1.0.0-1.bb
Traceback (most recent call last):
  File "Var <PN:append>", line 1, in <module>
  File "/jenkins/home/anaconda/ros1-noetic-honister/meta-ros/meta-ros-common/classes/ros_recipe_now_generated.bbclass", line 7, in ros_recipe_now_generated__get_suffix(d=<bb.data_smart.DataSmart object at 0x7f9fe5260898>):
     def ros_recipe_now_generated__get_suffix(d):
    >    pn = bb.parse.BBHandler.vars_from_file(d.getVar('FILE', False),d)[0] or 'defaultpkgname'
         return bb.utils.contains('ROS_SUPERFLORE_GENERATED_RECIPES', pn, '-notgenerated', '', d)
bb.data_smart.ExpansionError: Failure expanding variable PN:append, expression was ${@ros_recipe_now_generated__get_suffix(d)} which triggered exception AttributeError: module 'bb.parse.parse_py.BBHandler' has no attribute 'vars_from_file'
The variable dependency chain for the failure is: PN:append

Signed-off-by: Martin Jansa <martin.jansa@lge.com>