### PR TITLE
[dunfell][gatesgarth][hardknott][honister] gpsd-client: Fix-build-with-gpsd-3.23.1

### DIFF
--- a/meta-ros1-melodic/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
+++ b/meta-ros1-melodic/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
@@ -1,4 +1,4 @@
-From aef31bd72f0824bbb73ad92ecaeb02c268c471ba Mon Sep 17 00:00:00 2001
+From d7f0e9ad9f6d471ade3e1046b8a244acedaaac20 Mon Sep 17 00:00:00 2001
 From: Martin Jansa <martin.jansa@lge.com>
 Date: Wed, 25 Aug 2021 02:50:00 -0700
 Subject: [PATCH] Fix build with gpsd-3.21
@@ -6,18 +6,17 @@ Subject: [PATCH] Fix build with gpsd-3.21
 Adapt to changes from this commit:
 https://gitlab.com/gpsd/gpsd/-/commit/29991d6ffeb41ecfc8297db68bb68be0128c8514
 
-Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39]
-
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
 Signed-off-by: Martin Jansa <martin.jansa@lge.com>
 ---
  src/client.cpp | 13 +++++++++++++
  1 file changed, 13 insertions(+)
 
 diff --git a/src/client.cpp b/src/client.cpp
-index 3df33db..8bb0189 100644
+index 45258bc..ac391e0 100644
 --- a/src/client.cpp
 +++ b/src/client.cpp
-@@ -143,13 +143,21 @@ class GPSDClient {
+@@ -148,13 +148,22 @@ class GPSDClient {
  #endif
        }
  
@@ -26,6 +25,7 @@ index 3df33db..8bb0189 100644
 +#else
        if ((p->status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
 +#endif
++
          status.status = 0; // FIXME: gpsmm puts its constants in the global
                             // namespace, so `GPSStatus::STATUS_FIX' is illegal.
  
@@ -39,7 +39,7 @@ index 3df33db..8bb0189 100644
            status.status |= 18; // same here
  #endif
  
-@@ -212,7 +221,11 @@ class GPSDClient {
+@@ -228,7 +237,11 @@ class GPSDClient {
         * so we need to use the ROS message's integer values
         * for status.status
         */

--- a/meta-ros1-melodic/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
+++ b/meta-ros1-melodic/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
@@ -1,0 +1,77 @@
+From 060bec9c5158f576be0912d0c22caa55f49ac526 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:08:14 -0700
+Subject: [PATCH] Fix build with gpsd-3.23.1
+
+* there were 3 API breaking changes in 3.23.1 point release without bumping GPSD_API_MAJOR_VERSION:
+
+  Change STATUS_NO_FIX to STATUS_UNK to avoid confusion with fix mode.
+  Change STATUS_FIX to STATUS_GPS to avoid confusion with fix mode.
+  Change STATUS_DGPS_FIX to STATUS_DGPS to avoid confusion with fix mode.
+
+  https://gitlab.com/gpsd/gpsd/-/commit/d4a4d8d3606fd50f10bcd20096a8a0cdb8b2d427
+  https://gitlab.com/gpsd/gpsd/-/commit/af3b7dc0d1fc8b912ea2ef3df4a74498ccade85a
+  https://gitlab.com/gpsd/gpsd/-/commit/7d7b889f5ca9ec0bdef5fcea3da0e320eb8ceb97
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index ac391e0..687fdb7 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -149,7 +149,11 @@ class GPSDClient {
+       }
+ 
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
++#else
++      if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
++#endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
+ #endif
+@@ -160,7 +164,11 @@ class GPSDClient {
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
++#else
++        if (p->fix.status & STATUS_DGPS)
++#endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+ #endif
+@@ -242,15 +250,27 @@ class GPSDClient {
+ #else
+       switch (p->status) {
+ #endif
++#ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
++#else
++        case STATUS_UNK:
++#endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
++#ifdef STATUS_FIX
+         case STATUS_FIX:
++#else
++        case STATUS_GPS:
++#endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6 
++#ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
++#else
++        case STATUS_DGPS:
++#endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;
+ #endif

--- a/meta-ros1-melodic/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
+++ b/meta-ros1-melodic/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
@@ -1,0 +1,74 @@
+From 99b78aef98be3a9eb0346b558c3ba179c8367d4e Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:13:53 -0700
+Subject: [PATCH] Be a bit more strict when checking the symbols defined in
+ GPSD_API_MAJOR_VERSION 12
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index 687fdb7..0987fb8 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -151,8 +151,10 @@ class GPSDClient {
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
+-#else
++#elif defined STATUS_GPS
+       if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
+@@ -166,8 +168,10 @@ class GPSDClient {
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
+-#else
++#elif defined STATUS_DGPS
+         if (p->fix.status & STATUS_DGPS)
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+@@ -252,15 +256,19 @@ class GPSDClient {
+ #endif
+ #ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
+-#else
++#elif defined STATUS_UNK
+         case STATUS_UNK:
++#else
++#error "Either STATUS_NO_FIX or STATUS_UNK should be defined"
+ #endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
+ #ifdef STATUS_FIX
+         case STATUS_FIX:
+-#else
++#elif defined STATUS_GPS
+         case STATUS_GPS:
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+@@ -268,8 +276,10 @@ class GPSDClient {
+ #if GPSD_API_MAJOR_VERSION != 6 
+ #ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
+-#else
++#elif defined STATUS_DGPS
+         case STATUS_DGPS:
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;

--- a/meta-ros1-melodic/recipes-bbappends/gps-umd/gpsd-client_0.3.1-1.bbappend
+++ b/meta-ros1-melodic/recipes-bbappends/gps-umd/gpsd-client_0.3.1-1.bbappend
@@ -4,6 +4,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://0001-Fix-build-with-gpsd-3.20.patch \
     file://0001-Fix-build-with-gpsd-3.21.patch \
+    file://0002-Fix-build-with-gpsd-3.23.1.patch \
+    file://0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch \
 "
 
 inherit pkgconfig

--- a/meta-ros1-noetic/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
+++ b/meta-ros1-noetic/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
@@ -1,4 +1,4 @@
-From aef31bd72f0824bbb73ad92ecaeb02c268c471ba Mon Sep 17 00:00:00 2001
+From d7f0e9ad9f6d471ade3e1046b8a244acedaaac20 Mon Sep 17 00:00:00 2001
 From: Martin Jansa <martin.jansa@lge.com>
 Date: Wed, 25 Aug 2021 02:50:00 -0700
 Subject: [PATCH] Fix build with gpsd-3.21
@@ -6,18 +6,17 @@ Subject: [PATCH] Fix build with gpsd-3.21
 Adapt to changes from this commit:
 https://gitlab.com/gpsd/gpsd/-/commit/29991d6ffeb41ecfc8297db68bb68be0128c8514
 
-Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39]
-
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
 Signed-off-by: Martin Jansa <martin.jansa@lge.com>
 ---
  src/client.cpp | 13 +++++++++++++
  1 file changed, 13 insertions(+)
 
 diff --git a/src/client.cpp b/src/client.cpp
-index 3df33db..8bb0189 100644
+index 45258bc..ac391e0 100644
 --- a/src/client.cpp
 +++ b/src/client.cpp
-@@ -143,13 +143,21 @@ class GPSDClient {
+@@ -148,13 +148,22 @@ class GPSDClient {
  #endif
        }
  
@@ -26,6 +25,7 @@ index 3df33db..8bb0189 100644
 +#else
        if ((p->status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
 +#endif
++
          status.status = 0; // FIXME: gpsmm puts its constants in the global
                             // namespace, so `GPSStatus::STATUS_FIX' is illegal.
  
@@ -39,7 +39,7 @@ index 3df33db..8bb0189 100644
            status.status |= 18; // same here
  #endif
  
-@@ -212,7 +221,11 @@ class GPSDClient {
+@@ -228,7 +237,11 @@ class GPSDClient {
         * so we need to use the ROS message's integer values
         * for status.status
         */

--- a/meta-ros1-noetic/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
+++ b/meta-ros1-noetic/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
@@ -1,0 +1,77 @@
+From 060bec9c5158f576be0912d0c22caa55f49ac526 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:08:14 -0700
+Subject: [PATCH] Fix build with gpsd-3.23.1
+
+* there were 3 API breaking changes in 3.23.1 point release without bumping GPSD_API_MAJOR_VERSION:
+
+  Change STATUS_NO_FIX to STATUS_UNK to avoid confusion with fix mode.
+  Change STATUS_FIX to STATUS_GPS to avoid confusion with fix mode.
+  Change STATUS_DGPS_FIX to STATUS_DGPS to avoid confusion with fix mode.
+
+  https://gitlab.com/gpsd/gpsd/-/commit/d4a4d8d3606fd50f10bcd20096a8a0cdb8b2d427
+  https://gitlab.com/gpsd/gpsd/-/commit/af3b7dc0d1fc8b912ea2ef3df4a74498ccade85a
+  https://gitlab.com/gpsd/gpsd/-/commit/7d7b889f5ca9ec0bdef5fcea3da0e320eb8ceb97
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index ac391e0..687fdb7 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -149,7 +149,11 @@ class GPSDClient {
+       }
+ 
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
++#else
++      if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
++#endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
+ #endif
+@@ -160,7 +164,11 @@ class GPSDClient {
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
++#else
++        if (p->fix.status & STATUS_DGPS)
++#endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+ #endif
+@@ -242,15 +250,27 @@ class GPSDClient {
+ #else
+       switch (p->status) {
+ #endif
++#ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
++#else
++        case STATUS_UNK:
++#endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
++#ifdef STATUS_FIX
+         case STATUS_FIX:
++#else
++        case STATUS_GPS:
++#endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6 
++#ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
++#else
++        case STATUS_DGPS:
++#endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;
+ #endif

--- a/meta-ros1-noetic/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
+++ b/meta-ros1-noetic/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
@@ -1,0 +1,74 @@
+From 99b78aef98be3a9eb0346b558c3ba179c8367d4e Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:13:53 -0700
+Subject: [PATCH] Be a bit more strict when checking the symbols defined in
+ GPSD_API_MAJOR_VERSION 12
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index 687fdb7..0987fb8 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -151,8 +151,10 @@ class GPSDClient {
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
+-#else
++#elif defined STATUS_GPS
+       if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance && std::isnan(p->fix.epx))) {
+@@ -166,8 +168,10 @@ class GPSDClient {
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
+-#else
++#elif defined STATUS_DGPS
+         if (p->fix.status & STATUS_DGPS)
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+@@ -252,15 +256,19 @@ class GPSDClient {
+ #endif
+ #ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
+-#else
++#elif defined STATUS_UNK
+         case STATUS_UNK:
++#else
++#error "Either STATUS_NO_FIX or STATUS_UNK should be defined"
+ #endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
+ #ifdef STATUS_FIX
+         case STATUS_FIX:
+-#else
++#elif defined STATUS_GPS
+         case STATUS_GPS:
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+@@ -268,8 +276,10 @@ class GPSDClient {
+ #if GPSD_API_MAJOR_VERSION != 6 
+ #ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
+-#else
++#elif defined STATUS_DGPS
+         case STATUS_DGPS:
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;

--- a/meta-ros1-noetic/recipes-bbappends/gps-umd/gpsd-client_0.3.2-1.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/gps-umd/gpsd-client_0.3.2-1.bbappend
@@ -3,6 +3,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://0001-Fix-build-with-gpsd-3.21.patch \
+    file://0002-Fix-build-with-gpsd-3.23.1.patch \
+    file://0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch \
 "
 
 inherit pkgconfig

--- a/meta-ros2-dashing/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
+++ b/meta-ros2-dashing/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
@@ -1,4 +1,4 @@
-From f27a6a87e252666fdbdd8c51eab2432a097a0772 Mon Sep 17 00:00:00 2001
+From 5ca854acfedf9cb19ba6bdf189ce77968e083edb Mon Sep 17 00:00:00 2001
 From: Martin Jansa <martin.jansa@lge.com>
 Date: Wed, 25 Aug 2021 02:50:00 -0700
 Subject: [PATCH] Fix build with gpsd-3.21
@@ -6,8 +6,7 @@ Subject: [PATCH] Fix build with gpsd-3.21
 Adapt to changes from this commit:
 https://gitlab.com/gpsd/gpsd/-/commit/29991d6ffeb41ecfc8297db68bb68be0128c8514
 
-Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39]
-
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
 Signed-off-by: Martin Jansa <martin.jansa@lge.com>
 ---
  src/client.cpp | 12 ++++++++++++

--- a/meta-ros2-dashing/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
+++ b/meta-ros2-dashing/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
@@ -1,0 +1,77 @@
+From 3d2cd456f3bbc1f7450df591c7947a323c7c9177 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:08:14 -0700
+Subject: [PATCH] Fix build with gpsd-3.23.1
+
+* there ware 3 API breaking changes in 3.23.1 point release without bumping GPSD_API_MAJOR_VERSION:
+
+  Change STATUS_NO_FIX to STATUS_UNK to avoid confusion with fix mode.
+  Change STATUS_FIX to STATUS_GPS to avoid confusion with fix mode.
+  Change STATUS_DGPS_FIX to STATUS_DGPS to avoid confusion with fix mode.
+
+  https://gitlab.com/gpsd/gpsd/-/commit/d4a4d8d3606fd50f10bcd20096a8a0cdb8b2d427
+  https://gitlab.com/gpsd/gpsd/-/commit/af3b7dc0d1fc8b912ea2ef3df4a74498ccade85a
+  https://gitlab.com/gpsd/gpsd/-/commit/7d7b889f5ca9ec0bdef5fcea3da0e320eb8ceb97
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index 28c7215..b4347b5 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -153,7 +153,11 @@ namespace gpsd_client
+       }
+ 
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#else
++      if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+ #endif
+@@ -164,7 +168,11 @@ namespace gpsd_client
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
++#else
++        if (p->fix.status & STATUS_DGPS)
++#endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+ #endif
+@@ -248,15 +256,27 @@ namespace gpsd_client
+       switch (p->status)
+ #endif
+       {
++#ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
++#else
++        case STATUS_UNK:
++#endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
++#ifdef STATUS_FIX
+         case STATUS_FIX:
++#else
++        case STATUS_GPS:
++#endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
++#ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
++#else
++        case STATUS_DGPS:
++#endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;
+ #endif

--- a/meta-ros2-dashing/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
+++ b/meta-ros2-dashing/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
@@ -1,0 +1,74 @@
+From 85b152bc5694b9124949661aa07f75e083609f6d Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:13:53 -0700
+Subject: [PATCH] Be a bit more strict when checking the symbols defined in
+ GPSD_API_MAJOR_VERSION 12
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index b4347b5..9f2ceb7 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -155,8 +155,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+-#else
++#elif defined STATUS_GPS
+       if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+@@ -170,8 +172,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
+-#else
++#elif defined STATUS_DGPS
+         if (p->fix.status & STATUS_DGPS)
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+@@ -258,15 +262,19 @@ namespace gpsd_client
+       {
+ #ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
+-#else
++#elif defined STATUS_UNK
+         case STATUS_UNK:
++#else
++#error "Either STATUS_NO_FIX or STATUS_UNK should be defined"
+ #endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
+ #ifdef STATUS_FIX
+         case STATUS_FIX:
+-#else
++#elif defined STATUS_GPS
+         case STATUS_GPS:
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+@@ -274,8 +282,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION != 6
+ #ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
+-#else
++#elif defined STATUS_DGPS
+         case STATUS_DGPS:
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;

--- a/meta-ros2-dashing/recipes-bbappends/gps-umd/gpsd-client_1.0.4-1.bbappend
+++ b/meta-ros2-dashing/recipes-bbappends/gps-umd/gpsd-client_1.0.4-1.bbappend
@@ -3,6 +3,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://0001-Fix-build-with-gpsd-3.21.patch \
+    file://0002-Fix-build-with-gpsd-3.23.1.patch \
+    file://0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch \
 "
 
 inherit pkgconfig

--- a/meta-ros2-eloquent/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
+++ b/meta-ros2-eloquent/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
@@ -1,4 +1,4 @@
-From f27a6a87e252666fdbdd8c51eab2432a097a0772 Mon Sep 17 00:00:00 2001
+From 5ca854acfedf9cb19ba6bdf189ce77968e083edb Mon Sep 17 00:00:00 2001
 From: Martin Jansa <martin.jansa@lge.com>
 Date: Wed, 25 Aug 2021 02:50:00 -0700
 Subject: [PATCH] Fix build with gpsd-3.21
@@ -6,8 +6,7 @@ Subject: [PATCH] Fix build with gpsd-3.21
 Adapt to changes from this commit:
 https://gitlab.com/gpsd/gpsd/-/commit/29991d6ffeb41ecfc8297db68bb68be0128c8514
 
-Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39]
-
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
 Signed-off-by: Martin Jansa <martin.jansa@lge.com>
 ---
  src/client.cpp | 12 ++++++++++++

--- a/meta-ros2-eloquent/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
+++ b/meta-ros2-eloquent/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
@@ -1,0 +1,77 @@
+From 3d2cd456f3bbc1f7450df591c7947a323c7c9177 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:08:14 -0700
+Subject: [PATCH] Fix build with gpsd-3.23.1
+
+* there ware 3 API breaking changes in 3.23.1 point release without bumping GPSD_API_MAJOR_VERSION:
+
+  Change STATUS_NO_FIX to STATUS_UNK to avoid confusion with fix mode.
+  Change STATUS_FIX to STATUS_GPS to avoid confusion with fix mode.
+  Change STATUS_DGPS_FIX to STATUS_DGPS to avoid confusion with fix mode.
+
+  https://gitlab.com/gpsd/gpsd/-/commit/d4a4d8d3606fd50f10bcd20096a8a0cdb8b2d427
+  https://gitlab.com/gpsd/gpsd/-/commit/af3b7dc0d1fc8b912ea2ef3df4a74498ccade85a
+  https://gitlab.com/gpsd/gpsd/-/commit/7d7b889f5ca9ec0bdef5fcea3da0e320eb8ceb97
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index 28c7215..b4347b5 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -153,7 +153,11 @@ namespace gpsd_client
+       }
+ 
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#else
++      if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+ #endif
+@@ -164,7 +168,11 @@ namespace gpsd_client
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
++#else
++        if (p->fix.status & STATUS_DGPS)
++#endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+ #endif
+@@ -248,15 +256,27 @@ namespace gpsd_client
+       switch (p->status)
+ #endif
+       {
++#ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
++#else
++        case STATUS_UNK:
++#endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
++#ifdef STATUS_FIX
+         case STATUS_FIX:
++#else
++        case STATUS_GPS:
++#endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
++#ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
++#else
++        case STATUS_DGPS:
++#endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;
+ #endif

--- a/meta-ros2-eloquent/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
+++ b/meta-ros2-eloquent/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
@@ -1,0 +1,74 @@
+From 85b152bc5694b9124949661aa07f75e083609f6d Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:13:53 -0700
+Subject: [PATCH] Be a bit more strict when checking the symbols defined in
+ GPSD_API_MAJOR_VERSION 12
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index b4347b5..9f2ceb7 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -155,8 +155,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+-#else
++#elif defined STATUS_GPS
+       if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+@@ -170,8 +172,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
+-#else
++#elif defined STATUS_DGPS
+         if (p->fix.status & STATUS_DGPS)
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+@@ -258,15 +262,19 @@ namespace gpsd_client
+       {
+ #ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
+-#else
++#elif defined STATUS_UNK
+         case STATUS_UNK:
++#else
++#error "Either STATUS_NO_FIX or STATUS_UNK should be defined"
+ #endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
+ #ifdef STATUS_FIX
+         case STATUS_FIX:
+-#else
++#elif defined STATUS_GPS
+         case STATUS_GPS:
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+@@ -274,8 +282,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION != 6
+ #ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
+-#else
++#elif defined STATUS_DGPS
+         case STATUS_DGPS:
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;

--- a/meta-ros2-eloquent/recipes-bbappends/gps-umd/gpsd-client_1.0.4-1.bbappend
+++ b/meta-ros2-eloquent/recipes-bbappends/gps-umd/gpsd-client_1.0.4-1.bbappend
@@ -3,6 +3,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://0001-Fix-build-with-gpsd-3.21.patch \
+    file://0002-Fix-build-with-gpsd-3.23.1.patch \
+    file://0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch \
 "
 
 inherit pkgconfig

--- a/meta-ros2-foxy/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
+++ b/meta-ros2-foxy/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
@@ -1,4 +1,4 @@
-From f27a6a87e252666fdbdd8c51eab2432a097a0772 Mon Sep 17 00:00:00 2001
+From 5ca854acfedf9cb19ba6bdf189ce77968e083edb Mon Sep 17 00:00:00 2001
 From: Martin Jansa <martin.jansa@lge.com>
 Date: Wed, 25 Aug 2021 02:50:00 -0700
 Subject: [PATCH] Fix build with gpsd-3.21
@@ -6,8 +6,7 @@ Subject: [PATCH] Fix build with gpsd-3.21
 Adapt to changes from this commit:
 https://gitlab.com/gpsd/gpsd/-/commit/29991d6ffeb41ecfc8297db68bb68be0128c8514
 
-Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39]
-
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
 Signed-off-by: Martin Jansa <martin.jansa@lge.com>
 ---
  src/client.cpp | 12 ++++++++++++

--- a/meta-ros2-foxy/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
+++ b/meta-ros2-foxy/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
@@ -1,0 +1,77 @@
+From 3d2cd456f3bbc1f7450df591c7947a323c7c9177 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:08:14 -0700
+Subject: [PATCH] Fix build with gpsd-3.23.1
+
+* there ware 3 API breaking changes in 3.23.1 point release without bumping GPSD_API_MAJOR_VERSION:
+
+  Change STATUS_NO_FIX to STATUS_UNK to avoid confusion with fix mode.
+  Change STATUS_FIX to STATUS_GPS to avoid confusion with fix mode.
+  Change STATUS_DGPS_FIX to STATUS_DGPS to avoid confusion with fix mode.
+
+  https://gitlab.com/gpsd/gpsd/-/commit/d4a4d8d3606fd50f10bcd20096a8a0cdb8b2d427
+  https://gitlab.com/gpsd/gpsd/-/commit/af3b7dc0d1fc8b912ea2ef3df4a74498ccade85a
+  https://gitlab.com/gpsd/gpsd/-/commit/7d7b889f5ca9ec0bdef5fcea3da0e320eb8ceb97
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index 28c7215..b4347b5 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -153,7 +153,11 @@ namespace gpsd_client
+       }
+ 
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#else
++      if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+ #endif
+@@ -164,7 +168,11 @@ namespace gpsd_client
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
++#else
++        if (p->fix.status & STATUS_DGPS)
++#endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+ #endif
+@@ -248,15 +256,27 @@ namespace gpsd_client
+       switch (p->status)
+ #endif
+       {
++#ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
++#else
++        case STATUS_UNK:
++#endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
++#ifdef STATUS_FIX
+         case STATUS_FIX:
++#else
++        case STATUS_GPS:
++#endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
++#ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
++#else
++        case STATUS_DGPS:
++#endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;
+ #endif

--- a/meta-ros2-foxy/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
+++ b/meta-ros2-foxy/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
@@ -1,0 +1,74 @@
+From 85b152bc5694b9124949661aa07f75e083609f6d Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:13:53 -0700
+Subject: [PATCH] Be a bit more strict when checking the symbols defined in
+ GPSD_API_MAJOR_VERSION 12
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index b4347b5..9f2ceb7 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -155,8 +155,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+-#else
++#elif defined STATUS_GPS
+       if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+@@ -170,8 +172,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
+-#else
++#elif defined STATUS_DGPS
+         if (p->fix.status & STATUS_DGPS)
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+@@ -258,15 +262,19 @@ namespace gpsd_client
+       {
+ #ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
+-#else
++#elif defined STATUS_UNK
+         case STATUS_UNK:
++#else
++#error "Either STATUS_NO_FIX or STATUS_UNK should be defined"
+ #endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
+ #ifdef STATUS_FIX
+         case STATUS_FIX:
+-#else
++#elif defined STATUS_GPS
+         case STATUS_GPS:
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+@@ -274,8 +282,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION != 6
+ #ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
+-#else
++#elif defined STATUS_DGPS
+         case STATUS_DGPS:
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;

--- a/meta-ros2-foxy/recipes-bbappends/gps-umd/gpsd-client_1.0.4-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/gps-umd/gpsd-client_1.0.4-1.bbappend
@@ -3,6 +3,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://0001-Fix-build-with-gpsd-3.21.patch \
+    file://0002-Fix-build-with-gpsd-3.23.1.patch \
+    file://0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch \
 "
 
 inherit pkgconfig

--- a/meta-ros2-galactic/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
+++ b/meta-ros2-galactic/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
@@ -1,4 +1,4 @@
-From f27a6a87e252666fdbdd8c51eab2432a097a0772 Mon Sep 17 00:00:00 2001
+From 5ca854acfedf9cb19ba6bdf189ce77968e083edb Mon Sep 17 00:00:00 2001
 From: Martin Jansa <martin.jansa@lge.com>
 Date: Wed, 25 Aug 2021 02:50:00 -0700
 Subject: [PATCH] Fix build with gpsd-3.21
@@ -6,8 +6,7 @@ Subject: [PATCH] Fix build with gpsd-3.21
 Adapt to changes from this commit:
 https://gitlab.com/gpsd/gpsd/-/commit/29991d6ffeb41ecfc8297db68bb68be0128c8514
 
-Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39]
-
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
 Signed-off-by: Martin Jansa <martin.jansa@lge.com>
 ---
  src/client.cpp | 12 ++++++++++++

--- a/meta-ros2-galactic/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
+++ b/meta-ros2-galactic/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
@@ -1,0 +1,77 @@
+From 3d2cd456f3bbc1f7450df591c7947a323c7c9177 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:08:14 -0700
+Subject: [PATCH] Fix build with gpsd-3.23.1
+
+* there ware 3 API breaking changes in 3.23.1 point release without bumping GPSD_API_MAJOR_VERSION:
+
+  Change STATUS_NO_FIX to STATUS_UNK to avoid confusion with fix mode.
+  Change STATUS_FIX to STATUS_GPS to avoid confusion with fix mode.
+  Change STATUS_DGPS_FIX to STATUS_DGPS to avoid confusion with fix mode.
+
+  https://gitlab.com/gpsd/gpsd/-/commit/d4a4d8d3606fd50f10bcd20096a8a0cdb8b2d427
+  https://gitlab.com/gpsd/gpsd/-/commit/af3b7dc0d1fc8b912ea2ef3df4a74498ccade85a
+  https://gitlab.com/gpsd/gpsd/-/commit/7d7b889f5ca9ec0bdef5fcea3da0e320eb8ceb97
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index 28c7215..b4347b5 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -153,7 +153,11 @@ namespace gpsd_client
+       }
+ 
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#else
++      if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+ #endif
+@@ -164,7 +168,11 @@ namespace gpsd_client
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
++#else
++        if (p->fix.status & STATUS_DGPS)
++#endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+ #endif
+@@ -248,15 +256,27 @@ namespace gpsd_client
+       switch (p->status)
+ #endif
+       {
++#ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
++#else
++        case STATUS_UNK:
++#endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
++#ifdef STATUS_FIX
+         case STATUS_FIX:
++#else
++        case STATUS_GPS:
++#endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
++#ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
++#else
++        case STATUS_DGPS:
++#endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;
+ #endif

--- a/meta-ros2-galactic/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
+++ b/meta-ros2-galactic/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
@@ -1,0 +1,74 @@
+From 85b152bc5694b9124949661aa07f75e083609f6d Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:13:53 -0700
+Subject: [PATCH] Be a bit more strict when checking the symbols defined in
+ GPSD_API_MAJOR_VERSION 12
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index b4347b5..9f2ceb7 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -155,8 +155,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+-#else
++#elif defined STATUS_GPS
+       if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+@@ -170,8 +172,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
+-#else
++#elif defined STATUS_DGPS
+         if (p->fix.status & STATUS_DGPS)
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+@@ -258,15 +262,19 @@ namespace gpsd_client
+       {
+ #ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
+-#else
++#elif defined STATUS_UNK
+         case STATUS_UNK:
++#else
++#error "Either STATUS_NO_FIX or STATUS_UNK should be defined"
+ #endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
+ #ifdef STATUS_FIX
+         case STATUS_FIX:
+-#else
++#elif defined STATUS_GPS
+         case STATUS_GPS:
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+@@ -274,8 +282,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION != 6
+ #ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
+-#else
++#elif defined STATUS_DGPS
+         case STATUS_DGPS:
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;

--- a/meta-ros2-galactic/recipes-bbappends/gps-umd/gpsd-client_1.0.4-2.bbappend
+++ b/meta-ros2-galactic/recipes-bbappends/gps-umd/gpsd-client_1.0.4-2.bbappend
@@ -3,6 +3,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://0001-Fix-build-with-gpsd-3.21.patch \
+    file://0002-Fix-build-with-gpsd-3.23.1.patch \
+    file://0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch \
 "
 
 inherit pkgconfig

--- a/meta-ros2-rolling/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
+++ b/meta-ros2-rolling/recipes-bbappends/gps-umd/gpsd-client/0001-Fix-build-with-gpsd-3.21.patch
@@ -1,4 +1,4 @@
-From f27a6a87e252666fdbdd8c51eab2432a097a0772 Mon Sep 17 00:00:00 2001
+From 5ca854acfedf9cb19ba6bdf189ce77968e083edb Mon Sep 17 00:00:00 2001
 From: Martin Jansa <martin.jansa@lge.com>
 Date: Wed, 25 Aug 2021 02:50:00 -0700
 Subject: [PATCH] Fix build with gpsd-3.21
@@ -6,8 +6,7 @@ Subject: [PATCH] Fix build with gpsd-3.21
 Adapt to changes from this commit:
 https://gitlab.com/gpsd/gpsd/-/commit/29991d6ffeb41ecfc8297db68bb68be0128c8514
 
-Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39]
-
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
 Signed-off-by: Martin Jansa <martin.jansa@lge.com>
 ---
  src/client.cpp | 12 ++++++++++++

--- a/meta-ros2-rolling/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
+++ b/meta-ros2-rolling/recipes-bbappends/gps-umd/gpsd-client/0002-Fix-build-with-gpsd-3.23.1.patch
@@ -1,0 +1,77 @@
+From 3d2cd456f3bbc1f7450df591c7947a323c7c9177 Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:08:14 -0700
+Subject: [PATCH] Fix build with gpsd-3.23.1
+
+* there ware 3 API breaking changes in 3.23.1 point release without bumping GPSD_API_MAJOR_VERSION:
+
+  Change STATUS_NO_FIX to STATUS_UNK to avoid confusion with fix mode.
+  Change STATUS_FIX to STATUS_GPS to avoid confusion with fix mode.
+  Change STATUS_DGPS_FIX to STATUS_DGPS to avoid confusion with fix mode.
+
+  https://gitlab.com/gpsd/gpsd/-/commit/d4a4d8d3606fd50f10bcd20096a8a0cdb8b2d427
+  https://gitlab.com/gpsd/gpsd/-/commit/af3b7dc0d1fc8b912ea2ef3df4a74498ccade85a
+  https://gitlab.com/gpsd/gpsd/-/commit/7d7b889f5ca9ec0bdef5fcea3da0e320eb8ceb97
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index 28c7215..b4347b5 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -153,7 +153,11 @@ namespace gpsd_client
+       }
+ 
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#else
++      if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+ #endif
+@@ -164,7 +168,11 @@ namespace gpsd_client
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
+ #if GPSD_API_MAJOR_VERSION >= 10
++#ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
++#else
++        if (p->fix.status & STATUS_DGPS)
++#endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+ #endif
+@@ -248,15 +256,27 @@ namespace gpsd_client
+       switch (p->status)
+ #endif
+       {
++#ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
++#else
++        case STATUS_UNK:
++#endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
++#ifdef STATUS_FIX
+         case STATUS_FIX:
++#else
++        case STATUS_GPS:
++#endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+ // STATUS_DGPS_FIX was removed in API version 6 but re-added afterward
+ #if GPSD_API_MAJOR_VERSION != 6
++#ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
++#else
++        case STATUS_DGPS:
++#endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;
+ #endif

--- a/meta-ros2-rolling/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
+++ b/meta-ros2-rolling/recipes-bbappends/gps-umd/gpsd-client/0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch
@@ -1,0 +1,74 @@
+From 85b152bc5694b9124949661aa07f75e083609f6d Mon Sep 17 00:00:00 2001
+From: Martin Jansa <martin.jansa@lge.com>
+Date: Fri, 1 Oct 2021 06:13:53 -0700
+Subject: [PATCH] Be a bit more strict when checking the symbols defined in
+ GPSD_API_MAJOR_VERSION 12
+
+Upstream-Status: Submitted [https://github.com/swri-robotics/gps_umd/pull/39 https://github.com/swri-robotics/gps_umd/pull/40 https://github.com/swri-robotics/gps_umd/pull/41]
+Signed-off-by: Martin Jansa <martin.jansa@lge.com>
+---
+ src/client.cpp | 20 +++++++++++++++-----
+ 1 file changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/src/client.cpp b/src/client.cpp
+index b4347b5..9f2ceb7 100644
+--- a/src/client.cpp
++++ b/src/client.cpp
+@@ -155,8 +155,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_FIX
+       if ((p->fix.status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+-#else
++#elif defined STATUS_GPS
+       if ((p->fix.status & STATUS_GPS) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+ #else
+       if ((p->status & STATUS_FIX) && !(check_fix_by_variance_ && std::isnan(p->fix.epx)))
+@@ -170,8 +172,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION >= 10
+ #ifdef STATUS_DGPS_FIX
+         if (p->fix.status & STATUS_DGPS_FIX)
+-#else
++#elif defined STATUS_DGPS
+         if (p->fix.status & STATUS_DGPS)
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+ #else
+         if (p->status & STATUS_DGPS_FIX)
+@@ -258,15 +262,19 @@ namespace gpsd_client
+       {
+ #ifdef STATUS_NO_FIX
+         case STATUS_NO_FIX:
+-#else
++#elif defined STATUS_UNK
+         case STATUS_UNK:
++#else
++#error "Either STATUS_NO_FIX or STATUS_UNK should be defined"
+ #endif
+           fix->status.status = -1; // NavSatStatus::STATUS_NO_FIX;
+           break;
+ #ifdef STATUS_FIX
+         case STATUS_FIX:
+-#else
++#elif defined STATUS_GPS
+         case STATUS_GPS:
++#else
++#error "Either STATUS_FIX or STATUS_GPS should be defined"
+ #endif
+           fix->status.status = 0; // NavSatStatus::STATUS_FIX;
+           break;
+@@ -274,8 +282,10 @@ namespace gpsd_client
+ #if GPSD_API_MAJOR_VERSION != 6
+ #ifdef STATUS_DGPS_FIX
+         case STATUS_DGPS_FIX:
+-#else
++#elif defined STATUS_DGPS
+         case STATUS_DGPS:
++#else
++#error "Either STATUS_DGPS_FIX or STATUS_DGPS should be defined"
+ #endif
+           fix->status.status = 2; // NavSatStatus::STATUS_GBAS_FIX;
+           break;

--- a/meta-ros2-rolling/recipes-bbappends/gps-umd/gpsd-client_1.0.4-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/gps-umd/gpsd-client_1.0.4-1.bbappend
@@ -3,6 +3,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += " \
     file://0001-Fix-build-with-gpsd-3.21.patch \
+    file://0002-Fix-build-with-gpsd-3.23.1.patch \
+    file://0003-Be-a-bit-more-strict-when-checking-the-symbols-defin.patch \
 "
 
 inherit pkgconfig


### PR DESCRIPTION
* there were 3 API breaking changes in 3.23.1 point release without bumping GPSD_API_MAJOR_VERSION:

  Change STATUS_NO_FIX to STATUS_UNK to avoid confusion with fix mode.
  Change STATUS_FIX to STATUS_GPS to avoid confusion with fix mode.
  Change STATUS_DGPS_FIX to STATUS_DGPS to avoid confusion with fix mode.

  https://gitlab.com/gpsd/gpsd/-/commit/d4a4d8d3606fd50f10bcd20096a8a0cdb8b2d427
  https://gitlab.com/gpsd/gpsd/-/commit/af3b7dc0d1fc8b912ea2ef3df4a74498ccade85a
  https://gitlab.com/gpsd/gpsd/-/commit/7d7b889f5ca9ec0bdef5fcea3da0e320eb8ceb97

Signed-off-by: Martin Jansa <martin.jansa@lge.com>