### PR TITLE
[dunfell][gatesgarth][hardknott][honister] {galactic} mavros and tf-transformation fixes from #949 and #950

### DIFF
--- a/meta-ros-common/recipes-devtools/python/python3-transforms3d_0.3.1.bb
+++ b/meta-ros-common/recipes-devtools/python/python3-transforms3d_0.3.1.bb
@@ -1,0 +1,15 @@
+
+
+SUMMARY = "Functions for 3D coordinate transformations"
+SECTION = "devel/python"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://setup.py;beginline=36;endline=36;md5=6dd3a8a8bcf9d24e830b974bf9345e72"
+
+SRC_URI[sha256sum] = "404c7797c78aa461cb8043081901fc5517cef342d5ff56becd74a7967ba88d78"
+
+inherit pypi setuptools3
+
+RDEPENDS:${PN} += "\
+    ${PYTHON_PN}-numpy \
+"
+

--- a/meta-ros-common/recipes-extended/geographiclib/geographiclib-data_2021.1.bb
+++ b/meta-ros-common/recipes-extended/geographiclib/geographiclib-data_2021.1.bb
@@ -1,0 +1,44 @@
+# Load geographiclib data sets required by mavros
+# TODO: might be better to attach to mavros??
+
+# Rationale:
+# The mavros script '/usr/lib/mavros/install_geographiclib_datasets.sh' calls
+# bash scripts from geographiclib, which calls wget a couple of times.
+# We use here bitbake as a fetcher for these data files.
+
+# Mavros selects these files:
+# geoids egm96-5
+# gravity egm96
+# magnetic emm2015
+
+SUMMARY = "Data files for geographiclib."
+SECTION = "devel"
+# TODO: Check license of data files??
+LICENSE = "CLOSED"
+LIC_FILES_CHKSUM = ""
+
+SRC_URI = " \
+    https://downloads.sourceforge.net/project/geographiclib/geoids-distrib/egm96-5.tar.bz2?use_mirror=autoselect;name=geoids;downloadfilename=egm96-5.tar.bz2 \
+    https://downloads.sourceforge.net/project/geographiclib/gravity-distrib/egm96.tar.bz2?use_mirror=autoselect;name=gravity;downloadfilename=egm96.tar.bz2 \
+    https://downloads.sourceforge.net/project/geographiclib/magnetic-distrib/emm2015.tar.bz2?use_mirror=autoselect;name=magnetic;downloadfilename=emm2015.tar.bz2 \
+"
+
+SRC_URI[geoids.md5sum] = "6ae1c02c0506a686c9ad33be42cad0ae"
+SRC_URI[geoids.sha256sum] = "c46224f8f723dc915d97179f4e1580a98d6c742fe2b82cd8fef0ecaaad13e614"
+SRC_URI[gravity.md5sum] = "dcc1ab8e3433bd0add901b2f3e5caa76"
+SRC_URI[gravity.sha256sum] = "6fea4c6bd56ff8ac53dbdad8d5dd505c855471d0354c4abc5c5fe048bf8350c1"
+SRC_URI[magnetic.md5sum] = "18065cd3cc7369293d2a43c0c8f45315"
+SRC_URI[magnetic.sha256sum] = "8e71a9704c5f2714bb65581df68e30f0d84d0ad17286d00efb782e7232334c3f"
+
+do_install() {
+    install -d -m 0755 ${D}/${datadir}/GeographicLib/geoids
+    install -d -m 0755 ${D}/${datadir}/GeographicLib/gravity
+    install -d -m 0755 ${D}/${datadir}/GeographicLib/magnetic
+    install -D -m 0644 ${WORKDIR}/geoids/* ${D}/${datadir}/GeographicLib/geoids
+    install -D -m 0644 ${WORKDIR}/gravity/* ${D}/${datadir}/GeographicLib/gravity
+    install -D -m 0644 ${WORKDIR}/magnetic/* ${D}/${datadir}/GeographicLib/magnetic
+}
+
+FILES:${PN} = " \
+    ${datadir}/GeographicLib \
+"

--- a/meta-ros-common/recipes-extended/geographiclib/geographiclib_1.48.bb
+++ b/meta-ros-common/recipes-extended/geographiclib/geographiclib_1.48.bb
@@ -26,7 +26,8 @@ FILES:${PN}-python = "${libdir}/python"
 inherit cmake
 
 # enable both shared and static libraries (static is required by robot-localization-2.6.9-1 in melodic)
-EXTRA_OECMAKE += "-DGEOGRAPHICLIB_LIB_TYPE=BOTH"
+# Ensure geographiclib is configured to the proper folder to look for data files.
+EXTRA_OECMAKE += "-DGEOGRAPHICLIB_LIB_TYPE=BOTH -DGEOGRAPHICLIB_DATA=/usr/share/GeographicLib"
 
 # stage bindir to keep CMake happy
 # | -- Reading /jenkins/mjansa/build/ros/webos-melodic-hardknott/tmp-glibc/work/qemux86-webos-linux/robot-localization/2.6.9-1-r0/recipe-sysroot/usr/lib/cmake/GeographicLib/geographiclib-config.cmake

--- a/meta-ros2-galactic/recipes-bbappends/mavros/mavros_2.0.3-1.bbappend
+++ b/meta-ros2-galactic/recipes-bbappends/mavros/mavros_2.0.3-1.bbappend
@@ -2,9 +2,11 @@
 
 # ERROR: mavros-2.0.0-1-r0 do_package_qa: QA Issue: /usr/lib/mavros/install_geographiclib_datasets.sh contained in package mavros requires /bin/bash, but no providers found in RDEPENDS:mavros? [file-rdeps]
 # ERROR: mavros-2.0.0-1-r0 do_package_qa: QA Issue: /usr/lib/mavros/mav contained in package mavros requires /usr/bin/python3, but no providers found in RDEPENDS:mavros? [file-rdeps]
+# Ensure that the geographiclib data files are in place, by depending upon our geographiclib-data package.
 ROS_EXEC_DEPENDS += " \
     bash \
     python3-core \
+    geographiclib-data \
 "
 
 # This is needed only for webOS OSE, which uses busybox to provide

--- a/meta-ros2-galactic/recipes-bbappends/tf-transformations/tf-transformations_1.0.2-1.bbappend
+++ b/meta-ros2-galactic/recipes-bbappends/tf-transformations/tf-transformations_1.0.2-1.bbappend
@@ -1,0 +1,3 @@
+# The transforms3d python package is a runtime dependency.
+# It's probably missing from the package.xml dependencies list.
+RDEPENDS:${PN}:append = " python3-transforms3d"


### PR DESCRIPTION
Replaces https://github.com/ros/meta-ros/pull/950 and https://github.com/ros/meta-ros/pull/949.

Added small modifications, separated the runtime dependency to separate commit which can be easily cherry-picked to other ROS2 distros and added a tag in commit summary to indicate that this covers only galactic.

Also based on dunfell as all dunfell-applicable PRs are merged to dunfell first and then cherry-picked to gatesgarth, hardknott, honister, master branches.