### PR TITLE
Add nativesdk variant for ros packages listed as a build tool.

### DIFF
--- a/meta-ros-common/classes/ros_superflore_generated.bbclass
+++ b/meta-ros-common/classes/ros_superflore_generated.bbclass
@@ -4,7 +4,7 @@
 
 ROS_SUPERFLORE_GENERATED = "1"
 
-# If superflore found this BPN listed as a build tool, extend the recipe to build BPN-native.
-BBCLASSEXTEND:append = "${@bb.utils.contains('ROS_SUPERFLORE_GENERATED_BUILDTOOLS', '${BPN}-native', ' native', '', d)}"
+# If superflore found this BPN listed as a build tool, extend the recipe to build BPN-native and BPN-nativesdk.
+BBCLASSEXTEND:append = "${@bb.utils.contains('ROS_SUPERFLORE_GENERATED_BUILDTOOLS', '${BPN}-native', ' native nativesdk', '', d)}"
 
 inherit ros_component


### PR DESCRIPTION
This change allows the ros packages which are listed as build tools to have nativesdk packages next to native packages.