### PR TITLE
[dunfell][gatesgarth][hardknott][honister][kirkstone] ros_ament_cmake.bbclass: fix missed _i686 override conversion

### DIFF
--- a/meta-ros2/classes/ros_ament_cmake.bbclass
+++ b/meta-ros2/classes/ros_ament_cmake.bbclass
@@ -9,7 +9,7 @@ PYTHON_SOABI_ARCH_SUFFIX = "-gnu"
 PYTHON_SOABI_ARCH_SUFFIX:arm = ""
 # Another exception is i686 TUNE_ARCH in dunfell and newer with this change:
 # https://git.openembedded.org/openembedded-core/commit/?h=dunfell&id=6beab388e73b3ac6157650855a6c1fb1d71e8015
-PYTHON_SOABI_ARCH_i686 = "i386-${TARGET_OS}"
+PYTHON_SOABI_ARCH:i686 = "i386-${TARGET_OS}"
 PYTHON_SOABI = "cpython-${@d.getVar('PYTHON_BASEVERSION').replace('.', '')}${PYTHON_ABI}-${PYTHON_SOABI_ARCH}${PYTHON_SOABI_ARCH_SUFFIX}"
 
 EXTRA_OECMAKE:append = " -DBUILD_TESTING=OFF"


### PR DESCRIPTION
* causes cpython-310-i686-linux-gnu to be used instead of expected
  cpython-310-i386-linux-gnu in files like:
  /usr/lib/python3.10/site-packages/rcl_interfaces/rcl_interfaces_s__rosidl_typesupport_c.cpython-310-i686-linux-gnu.so

  which then results in:

  root@qemux86:~# ros2 topic list
  Traceback (most recent call last):
    File "/usr/lib/python3.10/site-packages/rosidl_generator_py/import_type_support_impl.py", line 46, in import_type_support
      return importlib.import_module(module_name, package=pkg_name)
    File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
    File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
    File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
    File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
  ModuleNotFoundError: No module named 'rcl_interfaces.rcl_interfaces_s__rosidl_typesupport_c'

Signed-off-by: Martin Jansa <martin.jansa@lge.com>