### PR TITLE
fix slam-toolbox build bugs for ver 2.4.1

### DIFF
--- a/meta-ros2-foxy/recipes-bbappends/slam-toolbox/slam-toolbox_2.4.1-1.bbappend
+++ b/meta-ros2-foxy/recipes-bbappends/slam-toolbox/slam-toolbox_2.4.1-1.bbappend
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Intel Corp.
+# Copyright (c) 2021 Intel Corp.
 
 ROS_BUILD_DEPENDS:append = " rosidl-typesupport-fastrtps-cpp rosidl-typesupport-fastrtps-c"
 ROS_BUILDTOOL_DEPENDS:append = " rosidl-default-generators-native rosidl-typesupport-fastrtps-cpp-native rosidl-typesupport-fastrtps-c-native"
@@ -7,6 +7,9 @@ ROS_EXEC_DEPENDS:append = " rosidl-typesupport-fastrtps-cpp rosidl-typesupport-f
 ROS_EXEC_DEPENDS:remove = "ceres-solver"
 
 FILES:${PN}-dev += "${datadir}/karto_sdk ${datadir}/solver_plugins.xml"
+FILES:${PN}-dev += "${datadir}/rviz_plugins.xml"
+
+inherit ${@bb.utils.contains_any('ROS_WORLD_SKIP_GROUPS', ['qt5', 'pyqt5'], '', 'cmake_qt5', d)}
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
-SRC_URI += "file://0001-fix-build-issue.patch"
+# SRC_URI += "file://0001-fix-build-issue.patch"


### PR DESCRIPTION
this PR fixes this build error:

ERROR: slam-toolbox-2.4.1-1-r0 do_patch: Applying patch '0001-fix-build-issue.patch' on target directory 'build/tmp/work/corei7-64-ecs-linux/slam-toolbox/2.4.1-1-r0/git'

the new version(ver2.4.1) of slam-toolbox has already involved the content of the patch.
