### PR TITLE
Kirkstone fixes

### DIFF
--- a/meta-ros-common/conf/ros-distro/ros-distro.conf
+++ b/meta-ros-common/conf/ros-distro/ros-distro.conf
@@ -14,7 +14,7 @@ ROS_DISTRO_COMPAT = "melodic dashing eloquent"
 
 # This variable is updated with the new release series as the first commit to [master] after the branch for the current release
 # series is created.
-ROS_OE_RELEASE_SERIES = "honister"
+ROS_OE_RELEASE_SERIES = "kirkstone"
 
 # "1" or "2"
 ROS_DISTRO_METADATA_VERSION_MAJOR = "${ROS_VERSION}"

--- a/meta-ros-common/recipes-devtools/python/python3-empy/0001-setup.py-distutils.core-setuptools.patch
+++ b/meta-ros-common/recipes-devtools/python/python3-empy/0001-setup.py-distutils.core-setuptools.patch
@@ -1,0 +1,29 @@
+From 6fd19144afea9b8a616f1baa2c6650cd64984430 Mon Sep 17 00:00:00 2001
+From: Tim Orling <tim.orling@konsulko.com>
+Date: Mon, 21 Mar 2022 22:44:01 -0700
+Subject: [PATCH] setup.py: distutils.core -> setuptools
+
+Also change #!/usr/bin/env python to python3
+
+Upstream-Status: Inactive Upstream
+
+Signed-off-by: Tim Orling <tim.orling@konsulko.com>
+---
+ setup.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/setup.py b/setup.py
+index 522e5ab..04d1af2 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,8 +1,8 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ # $Id: setup.py.pre 3116 2004-01-14 02:53:02Z max $ $Date: 2004-01-13 18:53:02 -0800 (Tue, 13 Jan 2004) $
+
+-from distutils.core import setup
++from setuptools import setup
+
+ DESCRIPTION = "A templating system for Python."
+

--- a/meta-ros-common/recipes-devtools/python/python3-empy_3.3.2.bb
+++ b/meta-ros-common/recipes-devtools/python/python3-empy_3.3.2.bb
@@ -1,3 +1,5 @@
 require python-empy.inc
 
-inherit distutils3
+inherit setuptools3
+
+SRC_URI += " file://0001-setup.py-distutils.core-setuptools.patch"

--- a/meta-ros-common/recipes-devtools/python/python3-pydot_1.4.1.bb
+++ b/meta-ros-common/recipes-devtools/python/python3-pydot_1.4.1.bb
@@ -2,4 +2,4 @@
 
 require python-pydot.inc
 
-inherit distutils3
+inherit setuptools3

--- a/meta-ros1/classes/ros_catkin.bbclass
+++ b/meta-ros1/classes/ros_catkin.bbclass
@@ -8,7 +8,7 @@ inherit ros_faulty_solibs
 # ROS_PYTHON_VERSION is usually set in generated/superflore-ros-distro.inc, but
 # in case superflore-ros-distro.inc isn't included default to 3
 ROS_PYTHON_VERSION ?= "3"
-inherit ${@'distutils3-base' if d.getVar('ROS_PYTHON_VERSION') == '3' else 'distutils-base'}
+inherit ${@'setuptools3-base' if d.getVar('ROS_PYTHON_VERSION') == '3' else 'distutils-base'}
 
 # noetic often provides python scripts which use "/usr/bin/env python" or "/usr/bin/python" shebang
 # while we want to install only python3 in the images and no /usr/bin/python symlink (as it cannot


### PR DESCRIPTION
This series mostly fixes deprecated distutils usage, but also changes the release compatibility from 'honister' to 'kirkstone'

a0e7adc03 ros_catkin.bbclass: inherit setuptools3-base
876a5e210 python3-pydot: inherit setuptools3
d0a89e1cc python3-empy: patch to use setuptools3
f2d275d1f ros-distro.conf: ROS_OE_RELEASE_SERIES -> kirkstone