### PR TITLE
[build] Workaround snappy fetch failure in [honister] and [master]

### DIFF
--- a/files/ros1-noetic-honister.mcf
+++ b/files/ros1-noetic-honister.mcf
@@ -78,4 +78,6 @@ Layers = [
 BblayersConfExtraLines = ['MCF_DISTRO ?= "' + OE_Distribution + '"',
                           'MCF_SUPPORTED_MACHINES ?= "' + ' '.join(Machines) + '"',
                           'MCF_OPENEMBEDDED_VERSION ?= "' + OpenEmbeddedVersion + '"',
+                          # Remove once the pin of [meta-oe] includes commit a750888a40a7e2f967dfd32ce7a6953dc6bf10f2:
+                          'SRC_URI:pn-snappy = "gitsm://github.com/google/snappy.git;protocol=https;branch=main file://0001-Add-inline-with-SNAPPY_ATTRIBUTE_ALWAYS_INLINE.patch"',
                          ]

--- a/files/ros1-noetic-kirkstone.mcf
+++ b/files/ros1-noetic-kirkstone.mcf
@@ -78,4 +78,6 @@ Layers = [
 BblayersConfExtraLines = ['MCF_DISTRO ?= "' + OE_Distribution + '"',
                           'MCF_SUPPORTED_MACHINES ?= "' + ' '.join(Machines) + '"',
                           'MCF_OPENEMBEDDED_VERSION ?= "' + OpenEmbeddedVersion + '"',
+                          # Remove once the pin of [meta-oe] includes commit a750888a40a7e2f967dfd32ce7a6953dc6bf10f2:
+                          'SRC_URI:pn-snappy = "gitsm://github.com/google/snappy.git;protocol=https;branch=main file://0001-Add-inline-with-SNAPPY_ATTRIBUTE_ALWAYS_INLINE.patch"',
                          ]


### PR DESCRIPTION
The [master] branch of snappy has been renamed to [main]. Override the `SRC_URI` setting in its recipe by adding `SRC_URI:pn-snappy override` to `BblayersConfExtraLines[]` to prevent these errors:
```
    WARNING: snappy-1.1.9-r0 do_fetch: Failed to fetch URL gitsm://github.com/google/snappy.git;protocol=https;branch=master, attempting MIRRORS if available
    ERROR: snappy-1.1.9-r0 do_fetch: Fetcher failure: Unable to find revision 2b63814b15a2aaae54b7943f0cd935892fae628f in branch master even from upstream
    ERROR: snappy-1.1.9-r0 do_fetch: Bitbake Fetcher Error: FetchError('Unable to fetch URL from any source.', 'gitsm://github.com/google/snappy.git;protocol=https;branch=master')
```
Revert this commit once the pin of meta-oe is moved to include commit a750888a40a7e2f967dfd32ce7a6953dc6bf10f2.