### PR TITLE
Fix QA license warning

### DIFF
--- a/meta-ros-common/recipes-extended/libflann/libflann_1.9.1.bb
+++ b/meta-ros-common/recipes-extended/libflann/libflann_1.9.1.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Fast Library for Approximate Nearest Neighbors"
 AUTHOR = "Marius Muja and David G. Lowe"
 HOMEPAGE = "http://www.cs.ubc.ca/~mariusm/index.php/FLANN/FLANN"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=395adad2339bd9ce5fef13d564a9681c"
 
 SRCREV = "06a49513138009d19a1f4e0ace67fbff13270c69"

--- a/meta-ros-common/recipes-extended/pcl/pcl.inc
+++ b/meta-ros-common/recipes-extended/pcl/pcl.inc
@@ -2,7 +2,7 @@
 
 DESCRIPTION = "The Point Cloud Library (or PCL) for point cloud processing."
 SECTION = "devel"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=5b8a2a1aa14e6de44b4273134946a34c"
 
 DEPENDS = "boost libflann libeigen qhull"


### PR DESCRIPTION
Currently, `libflann` and `pcl` recipes, both under BSD license dot not specify the BSD license version. As results, this causes QA warnings, such as:
```
WARNING: image-1.0-r0 do_rootfs: QA Issue: The license listed BSD was not in the licenses collected for recipe pcl [license-file-missing]
WARNING: libflann-1.9.1-r0 do_populate_lic: QA Issue: libflann: No generic license file exists for: BSD in any provider [license-exists]
```

This can be fixed by specifying the good license version, here BSD-3 for both recipes. 