### PR TITLE
[kirkstone] Allow moveit-core to build

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/moveit/moveit-core_2.5.5-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/moveit/moveit-core_2.5.5-1.bbappend
@@ -1,9 +1,10 @@
 # Copyright (c) 2021 LG Electronics, Inc.
-# Copyright (c) 2022 Wind River Systems, Inc.
+# Copyright (c) 2022-2023 Wind River Systems, Inc.
 
 ROS_BUILDTOOL_DEPENDS = " \
     rosidl-adapter-native \
     python3-numpy-native \
+    generate-parameter-library-py-native \
 "
 
 # tf2-kdl and angles are only in ROS_TEST_DEPENDS but CMake checks for it even with testing disabled

--- a/meta-ros2-humble/recipes-bbappends/rsl/rsl_0.2.2-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/rsl/rsl_0.2.2-1.bbappend
@@ -21,3 +21,14 @@
 # error: use of old-style cast to 'unsigned int' [-Werror=old-style-cast]
 CFLAGS += "-Wno-error=sign-conversion -Wno-error=old-style-cast"
 CXXFLAGS += "-Wno-error=sign-conversion -Wno-error=old-style-cast"
+
+# error declaration of 'error_msg' shadows a member of 'rclcpp::exceptions::InvalidNodeNameError' [-Werror=shadow]
+# error declaration of 'invalid_index' shadows a member of 'rclcpp::exceptions::InvalidNodeNameError' [-Werror=shadow]
+# error declaration of 'error_msg' shadows a member of 'rclcpp::exceptions::InvalidNamespaceError' [-Werror=shadow]
+# error declaration of 'invalid_index' shadows a member of 'rclcpp::exceptions::InvalidNamespaceError' [-Werror=shadow]
+# error declaration of 'error_msg' shadows a member of 'rclcpp::exceptions::InvalidTopicNameError' [-Werror=shadow]
+# error declaration of 'invalid_index' shadows a member of 'rclcpp::exceptions::InvalidTopicNameError' [-Werror=shadow]
+# error declaration of 'error_msg' shadows a member of 'rclcpp::exceptions::InvalidServiceNameError' [-Werror=shadow]
+# error declaration of 'invalid_index' shadows a member of 'rclcpp::exceptions::InvalidServiceNameError' [-Werror=shadow]
+CFLAGS += "-Wno-error=shadow"
+CXXFLAGS += "-Wno-error=shadow"


### PR DESCRIPTION
This addresses #1058 by providing an exception for a warning in RSL and adding a missing build tool dependency to moveit-core.