### PR TITLE
Add standard linux utils such as bash to ros-image-core

### DIFF
--- a/meta-ros-common/recipes-core/images/ros-image-core.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-core.bb
@@ -9,3 +9,12 @@ inherit ${ROS_DISTRO_TYPE}_image
 IMAGE_INSTALL:append = " \
     ros-core \
 "
+
+# The deploy code requires bash and
+# normal linux utilities not busybox ones.
+# See https://github.com/ros/meta-ros/issues/1068#issuecomment-1908098993
+CORE_IMAGE_EXTRA_INSTALL += "\
+    bash coreutils util-linux tar gzip bzip2 kmod \
+    python3-modules python3-misc \
+    e2fsprogs e2fsprogs-mke2fs parted \
+    "

--- a/meta-ros-common/recipes-core/images/ros-image-core.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-core.bb
@@ -1,9 +1,5 @@
+require ${COREBASE}/meta/recipes-extended/images/core-image-full-cmdline.bb
 require ros-image-minimal.bb
 
 SUMMARY = "A small image just capable of starting core ROS."
-DESCRIPTION = "Extends ros-image-minimal with standard Linux tools normally in Ubuntu Server that are used by ROS."
-
-CORE_IMAGE_EXTRA_INSTALL += "\
-    bash \
-    "
-
+DESCRIPTION = "Like ros-image-minimal, but with a more fully-featured Linux system."

--- a/meta-ros-common/recipes-core/images/ros-image-core.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-core.bb
@@ -1,20 +1,9 @@
-require ${COREBASE}/meta/recipes-core/images/core-image-minimal.bb
+require ros-image-minimal.bb
 
 SUMMARY = "A small image just capable of starting core ROS."
-DESCRIPTION = "${SUMMARY}"
+DESCRIPTION = "Extends ros-image-minimal with standard Linux tools normally in Ubuntu Server that are used by ROS."
 
-inherit ros_distro_${ROS_DISTRO}
-inherit ${ROS_DISTRO_TYPE}_image
-
-IMAGE_INSTALL:append = " \
-    ros-core \
-"
-
-# The deploy code requires bash and
-# normal linux utilities not busybox ones.
-# See https://github.com/ros/meta-ros/issues/1068#issuecomment-1908098993
 CORE_IMAGE_EXTRA_INSTALL += "\
-    bash coreutils util-linux tar gzip bzip2 kmod \
-    python3-modules python3-misc \
-    e2fsprogs e2fsprogs-mke2fs parted \
+    bash \
     "
+

--- a/meta-ros-common/recipes-core/images/ros-image-minimal.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-minimal.bb
@@ -1,0 +1,11 @@
+require ${COREBASE}/meta/recipes-core/images/core-image-minimal.bb
+
+SUMMARY = "A minimal image just capable of starting core ROS."
+DESCRIPTION = "${SUMMARY}"
+
+inherit ros_distro_${ROS_DISTRO}
+inherit ${ROS_DISTRO_TYPE}_image
+
+IMAGE_INSTALL:append = " \
+    ros-core \
+"

--- a/meta-ros-common/recipes-core/images/ros-image-minimal.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-minimal.bb
@@ -3,6 +3,8 @@ require ${COREBASE}/meta/recipes-core/images/core-image-minimal.bb
 SUMMARY = "A minimal image just capable of starting core ROS."
 DESCRIPTION = "${SUMMARY}"
 
+
+
 inherit ros_distro_${ROS_DISTRO}
 inherit ${ROS_DISTRO_TYPE}_image
 


### PR DESCRIPTION
# Purpose

* ROS requires standard tools beyond what is supplied by busybox
* The ROS setup.sh script relies on bash internally still

# Necessary Tests

- [ ] Source the ROS bash environment, and make sure less errors are reported.

# Documentation Needed

- [ ] Augment the standard release testing process to check that the ROS 2 CLI works reasonably well. 

# References

* https://github.com/ros/meta-ros/issues/1068#issuecomment-1908098993
* https://github.com/ros/meta-ros/discussions/1093#discussioncomment-8232698

# Backport

This should be backported to all maintained branches including kirkstone-next in support of the humble-kirkstone wiki