### PR TITLE
kirkstone: fix some build issues

### DIFF
--- a/meta-ros-common/conf/ros-distro/ros-distro.conf
+++ b/meta-ros-common/conf/ros-distro/ros-distro.conf
@@ -47,7 +47,7 @@ ROS_EXTRA_BUILDCFG_VARS ?= "DISTRO_NAME ROS_DISTRO ROS_VERSION ROS_PYTHON_VERSIO
 BUILDCFG_VARS:append = " ${ROS_EXTRA_BUILDCFG_VARS}"
 
 # Ignore metadata that requires meta-raspberrypi if it's not present.
-BBMASK:append =  "${@bb.utils.contains('BBFILE_COLLECTIONS', 'raspberrypi', '', 'recipes-bsp/bootfiles/rpi-config_%.bbappend', d)}"
+BBMASK:append =  " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'raspberrypi', '', 'recipes-bsp/bootfiles/rpi-config_%.bbappend', d)}"
 
 # "lapack" needs FORTRAN support
 require conf/ros-distro/include/enable-fortran.inc

--- a/meta-ros-common/conf/ros-distro/ros-distro.conf
+++ b/meta-ros-common/conf/ros-distro/ros-distro.conf
@@ -47,7 +47,7 @@ ROS_EXTRA_BUILDCFG_VARS ?= "DISTRO_NAME ROS_DISTRO ROS_VERSION ROS_PYTHON_VERSIO
 BUILDCFG_VARS:append = " ${ROS_EXTRA_BUILDCFG_VARS}"
 
 # Ignore metadata that requires meta-raspberrypi if it's not present.
-BBMASK +=  "${@bb.utils.contains('BBFILE_COLLECTIONS', 'raspberrypi', '', 'recipes-bsp/bootfiles/rpi-config_%.bbappend', d)}"
+BBMASK:append =  "${@bb.utils.contains('BBFILE_COLLECTIONS', 'raspberrypi', '', 'recipes-bsp/bootfiles/rpi-config_%.bbappend', d)}"
 
 # "lapack" needs FORTRAN support
 require conf/ros-distro/include/enable-fortran.inc

--- a/meta-ros2-humble/recipes-bbappends/ceres-solver/ceres-solver_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ceres-solver/ceres-solver_%.bbappend
@@ -1,0 +1,8 @@
+#Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+
+do_configure:prepend() {
+    if [ ! -d ${S}/.git/hooks/ ];then
+        mkdir ${S}/.git/hooks/
+    fi
+    touch ${S}/.git/hooks/commit-msg
+}

--- a/meta-ros2/classes/ros_ament_python.bbclass
+++ b/meta-ros2/classes/ros_ament_python.bbclass
@@ -1,6 +1,6 @@
 # Copyright (c) 2018-2019 LG Electronics, Inc.
 
-inherit setuptools3
+inherit setuptools3_legacy
 
 do_install:append() {
     mkdir -p ${D}${datadir}/ament_index/resource_index/packages


### PR DESCRIPTION
The PR is for below build issues, they should be applicable for other ROS distros.
1. rpi-config bbappend file has no corresponding recipe.
2. no hook directory found in ceres-solver source tree.