### PR TITLE
{rolling} fix compile of rsl

### DIFF
--- a/meta-ros2-rolling/recipes-bbappends/cpp-polyfills/tl-expected_1.0.2-4.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/cpp-polyfills/tl-expected_1.0.2-4.bbappend
@@ -1,0 +1,2 @@
+# Converting from Creative-Commons-Zero-v1.0-Universal to SPDX conform CC0-1.0
+LICENSE = "CC0-1.0"

--- a/meta-ros2-rolling/recipes-bbappends/rsl/rsl/0001-CMakeLists.txt-remove-Werror-from-compile-flags.patch
+++ b/meta-ros2-rolling/recipes-bbappends/rsl/rsl/0001-CMakeLists.txt-remove-Werror-from-compile-flags.patch
@@ -1,0 +1,30 @@
+From e11227c0de2deaf346118956fa7c946a42b455fb Mon Sep 17 00:00:00 2001
+From: Matthias Schoepfer <matthias.schoepfer@googlemail.com>
+Date: Thu, 11 Apr 2024 15:02:59 +0200
+Subject: [PATCH] CMakeLists.txt: remove -Werror from compile flags
+
+Removing from compile flags. Upstream has already changed this.
+
+Upstream-Status: inappropriate [similar patch already applied]
+
+Signed-off-by: Matthias Schoepfer <matthias.schoepfer@googlemail.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6d47b08..c7b66df 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -10,7 +10,7 @@ find_package(tcb_span REQUIRED)
+ find_package(tl_expected REQUIRED)
+ 
+ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+-    add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
++    add_compile_options(-Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion -Wold-style-cast)
+ endif()
+ 
+ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+-- 
+2.43.2
+

--- a/meta-ros2-rolling/recipes-bbappends/rsl/rsl_1.1.0-2.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/rsl/rsl_1.1.0-2.bbappend
@@ -1,34 +1,11 @@
-# Copyright (c) 2022 Wind River Systems, Inc.
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-# error: conversion to 'int' from 'unsigned int' may change the sign of the result [-Werror=sign-conversion]
-# error: conversion to 'long long int' from 'uint64_t' {aka 'long unsigned int'} may change the sign of the result [-Werror=sign-conversion]
-# error: conversion to 'long unsigned int' from 'int' may change the sign of the result [-Werror=sign-conversion]
-# error: conversion to 'std::__cxx11::basic_string<char>::size_type' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Werror=sign-conversion]
-# error: conversion to 'unsigned int' from 'int' may change the sign of the result [-Werror=sign-conversion]
-# error: signed conversion from 'unsigned int' to 'int' changes value from '2147483648' to '-2147483648' [-Werror=sign-conversion]
-# error: signed conversion from 'unsigned int' to 'int' changes value from '4294967295' to '-1' [-Werror=sign-conversion]
-# error: use of old-style cast to 'const double*' [-Werror=old-style-cast]
-# error: use of old-style cast to 'const Scalar*' [-Werror=old-style-cast]
-#error: use of old-style cast to 'const typename Eigen::internal::unpacket_traits<Packet>::type*' [-Werror=old-style-cast]
-# error: use of old-style cast to 'const typename Eigen::internal::unpacket_traits<typename Eigen::internal::conditional<Eigen::internal::gebp_traits<std::complex<_Tp>, std::complex<_Tp>, _ConjLhs, _ConjRhs, Arch, _PacketSize>::Vectorizable, typename Eigen::internal::packet_conditional<_PacketSize, typename Eigen::internal::packet_traits<T>::type, typename Eigen::internal::packet_traits<T>::half, typename Eigen::internal::unpacket_traits<typename Eigen::internal::packet_traits<T>::half>::half>::type, std::complex<_Tp> >::type>::type*' [-Werror=old-style-cast]
-# error: use of old-style cast to 'double*' [-Werror=old-style-cast]
-# error: use of old-style cast to 'Eigen::internal::SsePrefetchPtrType' {aka 'const char*'} [-Werror=old-style-cast]
-# error: use of old-style cast to 'enum Eigen::TransformTraits' [-Werror=old-style-cast]
-# error: use of old-style cast to 'int' [-Werror=old-style-cast]
-# error: use of old-style cast to 'LinearMatrixType*' [-Werror=old-style-cast]
-# error: use of old-style cast to '__m64*' [-Werror=old-style-cast]
-# error: use of old-style cast to 'Scalar*' [-Werror=old-style-cast]
-# error: use of old-style cast to 'unsigned int' [-Werror=old-style-cast]
-CFLAGS += "-Wno-error=sign-conversion -Wno-error=old-style-cast"
-CXXFLAGS += "-Wno-error=sign-conversion -Wno-error=old-style-cast"
+SRC_URI:append = " \
+    file://0001-CMakeLists.txt-remove-Werror-from-compile-flags.patch \
+"
 
-# error declaration of 'error_msg' shadows a member of 'rclcpp::exceptions::InvalidNodeNameError' [-Werror=shadow]
-# error declaration of 'invalid_index' shadows a member of 'rclcpp::exceptions::InvalidNodeNameError' [-Werror=shadow]
-# error declaration of 'error_msg' shadows a member of 'rclcpp::exceptions::InvalidNamespaceError' [-Werror=shadow]
-# error declaration of 'invalid_index' shadows a member of 'rclcpp::exceptions::InvalidNamespaceError' [-Werror=shadow]
-# error declaration of 'error_msg' shadows a member of 'rclcpp::exceptions::InvalidTopicNameError' [-Werror=shadow]
-# error declaration of 'invalid_index' shadows a member of 'rclcpp::exceptions::InvalidTopicNameError' [-Werror=shadow]
-# error declaration of 'error_msg' shadows a member of 'rclcpp::exceptions::InvalidServiceNameError' [-Werror=shadow]
-# error declaration of 'invalid_index' shadows a member of 'rclcpp::exceptions::InvalidServiceNameError' [-Werror=shadow]
-CFLAGS += "-Wno-error=shadow"
-CXXFLAGS += "-Wno-error=shadow"
+DEPENDS:append = " \
+   ament-package-native \
+   ament-cmake-libraries-native \
+   ament-cmake-native \
+"


### PR DESCRIPTION
The include of rclcpp caused some configure time errors because some ament packages were not found. Unfortunately, these build time dependencies did not properly propagate, so we need to add them here alongside a patch to remove -Werror from compile flags (newer compiler always finds new warnings).

Also changed license of tl-expected to proper SPDX naming.