### PR TITLE
{rolling} fix recipe append for shared-queues-vendor

### DIFF
--- a/meta-ros2-rolling/recipes-bbappends/rosbag2/shared-queues-vendor_0.24.0-3.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/rosbag2/shared-queues-vendor_0.24.0-3.bbappend
@@ -11,7 +11,7 @@ SRC_URI = " \
     git://github.com/cameron314/readerwriterqueue.git;protocol=https;name=singleproducerconsumer-upstream;destsuffix=git/singleproducerconsumer-upstream;branch=master \
     git://github.com/cameron314/concurrentqueue.git;protocol=https;name=concurrentqueue-upstream;destsuffix=git/concurrentqueue-upstream;branch=master \
 "
-SRCREV_release = "dc17fed08353f30a7e20676df7c8fc5e842ed011"
+SRCREV_release = "${SRCREV}"
 SRCREV_singleproducerconsumer-upstream = "ef7dfbf553288064347d51b8ac335f1ca489032a"
 SRCREV_concurrentqueue-upstream = "8f65a8734d77c3cc00d74c0532efca872931d3ce"
 


### PR DESCRIPTION
Updating the hash of the generated recipe. Unfortunately, a good solution (i.e. pulling the sources upstream & expect them to be in the same location) is a bit tricky.