### PR TITLE
{rolling} fix License to be SPDX conform

### DIFF
--- a/meta-ros2-rolling/recipes-bbappends/cpp-polyfills/tl-expected_1.0.2-4.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/cpp-polyfills/tl-expected_1.0.2-4.bbappend
@@ -1,0 +1,2 @@
+# Fixing BSD license not using correct SPDX Syntax
+LICENSE = "CC0-1.0"


### PR DESCRIPTION
Setting license to SPDX conform identifier "CC0-1.0".

Upstream-Status: Submitted [https://github.com/PickNikRobotics/cpp_polyfills/pull/3]