### PR TITLE
Change machine name from jetson-agx-xavier-devkit to jetson-orin-nano-devkit

### DIFF
--- a/kas/machine/jetson-orin-nano-devkit.yml
+++ b/kas/machine/jetson-orin-nano-devkit.yml
@@ -24,6 +24,6 @@ repos:
     path: "layers/meta-virtualization"
 
 local_conf_header:
-  jetson-agx-xavier-devkit: |
+  jetson-orin-nano-devkit: |
     # Set DISTRO_FEATURES to enable latent features in meta-virtualization
     DISTRO_FEATURES:append = " virtualization"


### PR DESCRIPTION
Change key name from jetson-agx-xavier-devkit to jetson-orin-nano-devkit on the local_conf_header.