### PR TITLE
{humble} sick-scan-xd: fix license string

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/sick-scan-xd/sick-scan-xd_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/sick-scan-xd/sick-scan-xd_%.bbappend
@@ -1,0 +1,2 @@
+_LICENSE := "${LICENSE}"
+LICENSE = "${@'${_LICENSE}'.replace('Apache-License,-Version-2.0,-see-"http-www.apache.org-licenses-LICENSE-2.0"', 'Apache-2.0')}"


### PR DESCRIPTION
The license string in the upstream project's xml is not a standard license string. Replace with one that will be recognized by bitbake.