### PR TITLE
{humble}: fix host path is included in cmake files.

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/urdfdom/urdfdom_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/urdfdom/urdfdom_%.bbappend
@@ -7,7 +7,7 @@ do_install:append() {
     for i in ${D}${libdir}/${ROS_BPN}/cmake/* ${D}${ros_libdir}/${ROS_BPN}/cmake/*; do
         if [ -f "$i" ]; then
             echo "sed -i -e s:${STAGING_DIR_TARGET}:"":g $i"
-            sed -i -e s:${STAGING_DIR_TARGET}:"":g $i
+            sed -i -e s:${STAGING_DIR_TARGET}:\${CMAKE_SYSROOT}:g $i
         fi
     done
 }

--- a/meta-ros2-humble/recipes-bbappends/urdfdom/urdfdom_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/urdfdom/urdfdom_%.bbappend
@@ -1,3 +1,13 @@
 # Copyright (c) 2020 LG Electronics, Inc.
 
 inherit ros_insane_dev_so
+
+do_install:append() {
+
+    for i in ${D}${libdir}/${ROS_BPN}/cmake/* ${D}${ros_libdir}/${ROS_BPN}/cmake/*; do
+        if [ -f "$i" ]; then
+            echo "sed -i -e s:${STAGING_DIR_TARGET}:"":g $i"
+            sed -i -e s:${STAGING_DIR_TARGET}:"":g $i
+        fi
+    done
+}


### PR DESCRIPTION
As mentioned in #1166 HOST path is included in cmake files. This is because urdfdom dependes on tinyxml which is build via makefile and it doesn't provide tinyxml.cmake. And urdfdom provides a [FindTinyXML.cmake](https://github.com/ros/urdfdom/blob/humble/cmake/FindTinyXML.cmake) to find it. Then absolute path is used in FindTinyXML.cmake.

There is an issue raised in urdfdom projet [202](https://github.com/ros/urdfdom/issues/202).  And urdfdom group had discussed this issue in https://discourse.ros.org/t/upcoming-api-break-in-urdfdom/34750. And they decided to use tinyxml2 which has good maintenance(tinyxml is no longer maintained). This is merged in master branch（https://github.com/ros/urdfdom/pull/186）.

Since with latest version of urdfdom, the issue should not present with tinyxml2 is used. So the PR is a workaround to remove host path in cmakes.