### PR TITLE
{humble}: Add compressed-depth-image-transport bbappend file

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/image-transport-plugins/compressed-depth-image-transport_2.5.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/image-transport-plugins/compressed-depth-image-transport_2.5.1-1.bbappend
@@ -1,0 +1,4 @@
+#Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved
+
+#compressed-depth-image-transport/2.5.1-1-r0/recipe-sysroot/usr/include/rcutils/rcutils/logging_macros.h:79:18: error: format not a string literal and no format arguments [-Werror=format-security]
+CXXFLAGS += "-Wno-format-security"


### PR DESCRIPTION
Fix format-security build failure since __VA_ARGS__ is used.

compressed-depth-image-transport/2.5.1-1-r0/recipe-sysroot/usr/ include/rcutils/rcutils/logging_macros.h:79:18: error: format not a string literal and no format arguments [-Werror=format-security]
    rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__);