### PR TITLE
Kirkstone fixes

### DIFF
--- a/meta-ros-common/recipes-devtools/python/python-sphinx.inc
+++ b/meta-ros-common/recipes-devtools/python/python-sphinx.inc
@@ -3,7 +3,7 @@
 DESCRIPTION = "Sphinx is a tool that makes it easy to create intelligent and beautiful documentation for Python projects"
 HOMEPAGE = "http://www.sphinx-doc.org"
 SECTION = "devel/python"
-LICENSE = "BSD-2-Clause & Python-2 & BSD-3-Clause & MIT"
+LICENSE = "BSD-2-Clause & Python-2.0 & BSD-3-Clause & MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d5575c977f2e4659ece47f731f2b8319"
 
 SRC_URI[md5sum] = "753731d5751991d9cc0c02b8994f21f6"

--- a/meta-ros-common/recipes-extended/suitesparse/suitesparse-cholmod_5.4.0.bb
+++ b/meta-ros-common/recipes-extended/suitesparse/suitesparse-cholmod_5.4.0.bb
@@ -2,7 +2,7 @@
 
 require suitesparse-5.4.0.inc
 
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM += "file://Doc/License.txt;md5=5d8c39b6ee2eb7c9e0e226a333be30cc"
 
 DEPENDS = " \

--- a/meta-ros-common/recipes-extended/suitesparse/suitesparse-cxsparse_5.4.0.bb
+++ b/meta-ros-common/recipes-extended/suitesparse/suitesparse-cxsparse_5.4.0.bb
@@ -2,7 +2,7 @@
 
 require suitesparse-5.4.0.inc
 
-LICENSE = "LGPL-2.1+"
+LICENSE = "LGPL-2.1-or-later"
 LIC_FILES_CHKSUM += "file://Doc/License.txt;md5=0e5191611fba4aac850756c5d598ff23"
 
 DEPENDS = "suitesparse-config"

--- a/meta-ros-common/recipes-extended/suitesparse/suitesparse-spqr_5.4.0.bb
+++ b/meta-ros-common/recipes-extended/suitesparse/suitesparse-spqr_5.4.0.bb
@@ -2,7 +2,7 @@
 
 require suitesparse-5.4.0.inc
 
-LICENSE = "GPL-2.0"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM += "file://Doc/License.txt;md5=1c0c48edf24526b3cda72ce1a8a20b1d"
 
 DEPENDS = " \

--- a/meta-ros1-noetic/recipes-bbappends/actionlib/actionlib/0001-Fix-build-with-boost-1.73.0.patch
+++ b/meta-ros1-noetic/recipes-bbappends/actionlib/actionlib/0001-Fix-build-with-boost-1.73.0.patch
@@ -38,11 +38,11 @@ Signed-off-by: Martin Jansa <martin.jansa@lge.com>
  13 files changed, 34 insertions(+), 34 deletions(-)
 
 diff --git a/include/actionlib/client/action_client.h b/include/actionlib/client/action_client.h
-index cfd64af..cb79ae2 100644
+index 85b32dc..21d0102 100644
 --- a/include/actionlib/client/action_client.h
 +++ b/include/actionlib/client/action_client.h
 @@ -236,17 +236,17 @@ private:
- 
+
      // Start publishers and subscribers
      goal_pub_ = queue_advertise<ActionGoal>("goal", static_cast<uint32_t>(pub_queue_size),
 -        boost::bind(&ConnectionMonitor::goalConnectCallback, connection_monitor_, _1),
@@ -57,13 +57,13 @@ index cfd64af..cb79ae2 100644
 +        boost::bind(&ConnectionMonitor::cancelConnectCallback, connection_monitor_, boost::placeholders::_1),
 +        boost::bind(&ConnectionMonitor::cancelDisconnectCallback, connection_monitor_, boost::placeholders::_1),
          queue);
- 
+
 -    manager_.registerSendGoalFunc(boost::bind(&ActionClientT::sendGoalFunc, this, _1));
 -    manager_.registerCancelFunc(boost::bind(&ActionClientT::sendCancelFunc, this, _1));
 +    manager_.registerSendGoalFunc(boost::bind(&ActionClientT::sendGoalFunc, this, boost::placeholders::_1));
 +    manager_.registerCancelFunc(boost::bind(&ActionClientT::sendCancelFunc, this, boost::placeholders::_1));
    }
- 
+
    template<class M>
 @@ -275,7 +275,7 @@ private:
      ops.datatype = ros::message_traits::datatype<M>();
@@ -75,35 +75,35 @@ index cfd64af..cb79ae2 100644
        );
      return n_.subscribe(ops);
 diff --git a/include/actionlib/client/goal_manager_imp.h b/include/actionlib/client/goal_manager_imp.h
-index 789ada0..30dbc35 100644
+index 28f4979..4e3281b 100644
 --- a/include/actionlib/client/goal_manager_imp.h
 +++ b/include/actionlib/client/goal_manager_imp.h
 @@ -74,7 +74,7 @@ ClientGoalHandle<ActionSpec> GoalManager<ActionSpec>::initGoal(const Goal & goal
- 
+
    boost::recursive_mutex::scoped_lock lock(list_mutex_);
    typename ManagedListT::Handle list_handle =
 -    list_.add(comm_state_machine, boost::bind(&GoalManagerT::listElemDeleter, this, _1), guard_);
 +    list_.add(comm_state_machine, boost::bind(&GoalManagerT::listElemDeleter, this, boost::placeholders::_1), guard_);
- 
+
    if (send_goal_func_) {
      send_goal_func_(action_goal);
 diff --git a/include/actionlib/client/simple_action_client.h b/include/actionlib/client/simple_action_client.h
-index 52637ed..cfbd206 100644
+index 436516f..02df1ae 100644
 --- a/include/actionlib/client/simple_action_client.h
 +++ b/include/actionlib/client/simple_action_client.h
 @@ -330,8 +330,8 @@ void SimpleActionClient<ActionSpec>::sendGoal(const Goal & goal,
    cur_simple_state_ = SimpleGoalState::PENDING;
- 
+
    // Send the goal to the ActionServer
 -  gh_ = ac_->sendGoal(goal, boost::bind(&SimpleActionClientT::handleTransition, this, _1),
 -      boost::bind(&SimpleActionClientT::handleFeedback, this, _1, _2));
 +  gh_ = ac_->sendGoal(goal, boost::bind(&SimpleActionClientT::handleTransition, this, boost::placeholders::_1),
 +      boost::bind(&SimpleActionClientT::handleFeedback, this, boost::placeholders::_1, boost::placeholders::_2));
  }
- 
+
  template<class ActionSpec>
 diff --git a/include/actionlib/managed_list.h b/include/actionlib/managed_list.h
-index 11c4889..b7f9231 100644
+index 2c91960..b2c4f89 100644
 --- a/include/actionlib/managed_list.h
 +++ b/include/actionlib/managed_list.h
 @@ -218,7 +218,7 @@ private:
@@ -113,43 +113,43 @@ index 11c4889..b7f9231 100644
 -    return add(elem, boost::bind(&ManagedList<T>::defaultDeleter, this, _1) );
 +    return add(elem, boost::bind(&ManagedList<T>::defaultDeleter, this, boost::placeholders::_1) );
    }
- 
+
    /**
 diff --git a/include/actionlib/one_shot_timer.h b/include/actionlib/one_shot_timer.h
-index e462abb..ccbf37f 100644
+index e3c821d..7839294 100644
 --- a/include/actionlib/one_shot_timer.h
 +++ b/include/actionlib/one_shot_timer.h
 @@ -60,7 +60,7 @@ public:
- 
+
    boost::function<void(const ros::TimerEvent & e)> getCb()
    {
 -    return boost::bind(&OneShotTimer::cb, this, _1);
 +    return boost::bind(&OneShotTimer::cb, this, boost::placeholders::_1);
    }
- 
+
    void registerOneShotCb(boost::function<void(const ros::TimerEvent & e)> callback)
 diff --git a/include/actionlib/server/action_server_imp.h b/include/actionlib/server/action_server_imp.h
 index 2a088b1..837b9c4 100644
 --- a/include/actionlib/server/action_server_imp.h
 +++ b/include/actionlib/server/action_server_imp.h
 @@ -172,15 +172,15 @@ void ActionServer<ActionSpec>::initialize()
- 
+
    if (status_frequency > 0) {
      status_timer_ = node_.createTimer(ros::Duration(1.0 / status_frequency),
 -        boost::bind(&ActionServer::publishStatus, this, _1));
 +        boost::bind(&ActionServer::publishStatus, this, boost::placeholders::_1));
    }
- 
+
    goal_sub_ = node_.subscribe<ActionGoal>("goal", static_cast<uint32_t>(sub_queue_size),
 -      boost::bind(&ActionServerBase<ActionSpec>::goalCallback, this, _1));
 +      boost::bind(&ActionServerBase<ActionSpec>::goalCallback, this, boost::placeholders::_1));
- 
+
    cancel_sub_ =
      node_.subscribe<actionlib_msgs::GoalID>("cancel", static_cast<uint32_t>(sub_queue_size),
 -      boost::bind(&ActionServerBase<ActionSpec>::cancelCallback, this, _1));
 +      boost::bind(&ActionServerBase<ActionSpec>::cancelCallback, this, boost::placeholders::_1));
  }
- 
+
  template<class ActionSpec>
 diff --git a/include/actionlib/server/service_server_imp.h b/include/actionlib/server/service_server_imp.h
 index ac5444d..2f0265e 100644
@@ -163,13 +163,13 @@ index ac5444d..2f0265e 100644
 +      boost::bind(&ServiceServerImpT::goalCB, this, boost::placeholders::_1), false));
    as_->start();
  }
- 
+
 diff --git a/include/actionlib/server/simple_action_server_imp.h b/include/actionlib/server/simple_action_server_imp.h
-index a5e51bb..d8b906a 100644
+index 0255515..a361cd7 100644
 --- a/include/actionlib/server/simple_action_server_imp.h
 +++ b/include/actionlib/server/simple_action_server_imp.h
 @@ -56,8 +56,8 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
- 
+
    // create the action server
    as_ = boost::shared_ptr<ActionServer<ActionSpec> >(new ActionServer<ActionSpec>(n_, name,
 -      boost::bind(&SimpleActionServer::goalCallback, this, _1),
@@ -178,7 +178,7 @@ index a5e51bb..d8b906a 100644
 +      boost::bind(&SimpleActionServer::preemptCallback, this, boost::placeholders::_1),
        auto_start));
  }
- 
+
 @@ -68,8 +68,8 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name, bool auto_s
  {
    // create the action server
@@ -188,8 +188,8 @@ index a5e51bb..d8b906a 100644
 +      boost::bind(&SimpleActionServer::goalCallback, this, boost::placeholders::_1),
 +      boost::bind(&SimpleActionServer::preemptCallback, this, boost::placeholders::_1),
        auto_start));
- 
-   if (execute_callback_ != NULL) {
+
+   if (execute_callback_) {
 @@ -85,8 +85,8 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(std::string name,
  {
    // create the action server
@@ -199,8 +199,8 @@ index a5e51bb..d8b906a 100644
 +      boost::bind(&SimpleActionServer::goalCallback, this, boost::placeholders::_1),
 +      boost::bind(&SimpleActionServer::preemptCallback, this, boost::placeholders::_1),
        true));
- 
-   if (execute_callback_ != NULL) {
+
+   if (execute_callback_) {
 @@ -104,8 +104,8 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
  {
    // create the action server
@@ -210,8 +210,8 @@ index a5e51bb..d8b906a 100644
 +      boost::bind(&SimpleActionServer::goalCallback, this, boost::placeholders::_1),
 +      boost::bind(&SimpleActionServer::preemptCallback, this, boost::placeholders::_1),
        auto_start));
- 
-   if (execute_callback_ != NULL) {
+
+   if (execute_callback_) {
 @@ -121,8 +121,8 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
  {
    // create the action server
@@ -221,8 +221,8 @@ index a5e51bb..d8b906a 100644
 +      boost::bind(&SimpleActionServer::goalCallback, this, boost::placeholders::_1),
 +      boost::bind(&SimpleActionServer::preemptCallback, this, boost::placeholders::_1),
        auto_start));
- 
-   if (execute_callback_ != NULL) {
+
+   if (execute_callback_) {
 @@ -138,8 +138,8 @@ SimpleActionServer<ActionSpec>::SimpleActionServer(ros::NodeHandle n, std::strin
  {
    // create the action server
@@ -232,27 +232,27 @@ index a5e51bb..d8b906a 100644
 +      boost::bind(&SimpleActionServer::goalCallback, this, boost::placeholders::_1),
 +      boost::bind(&SimpleActionServer::preemptCallback, this, boost::placeholders::_1),
        true));
- 
-   if (execute_callback_ != NULL) {
+
+   if (execute_callback_) {
 diff --git a/test/add_two_ints_server.cpp b/test/add_two_ints_server.cpp
 index 098c315..84ddace 100644
 --- a/test/add_two_ints_server.cpp
 +++ b/test/add_two_ints_server.cpp
 @@ -53,7 +53,7 @@ int main(int argc, char ** argv)
- 
+
    actionlib::ServiceServer service = actionlib::advertiseService<actionlib::TwoIntsAction>(n,
        "add_two_ints",
 -      boost::bind(add, _1, _2));
 +      boost::bind(add, boost::placeholders::_1, boost::placeholders::_2));
- 
+
    ros::spin();
- 
+
 diff --git a/test/ref_server.cpp b/test/ref_server.cpp
 index 1da0ab5..7aede23 100644
 --- a/test/ref_server.cpp
 +++ b/test/ref_server.cpp
 @@ -61,8 +61,8 @@ using namespace actionlib;
- 
+
  RefServer::RefServer(ros::NodeHandle & n, const std::string & name)
  : ActionServer<TestAction>(n, name,
 -    boost::bind(&RefServer::goalCallback, this, _1),
@@ -274,13 +274,13 @@ index 9e179c7..ed12d2b 100644
 +    boost::placeholders::_1));
    gh_ = new GoalHandle();
  }
- 
+
 diff --git a/test/simple_client_test.cpp b/test/simple_client_test.cpp
 index 341bbc9..ea40050 100644
 --- a/test/simple_client_test.cpp
 +++ b/test/simple_client_test.cpp
 @@ -106,7 +106,7 @@ TEST(SimpleClient, easy_callback)
- 
+
    bool called = false;
    goal.goal = 1;
 -  SimpleActionClient<TestAction>::SimpleDoneCallback func = boost::bind(&easyDoneCallback, &called, &client, _1, _2);
@@ -293,7 +293,7 @@ index 57aa9cd..b663ec4 100644
 --- a/test/simple_execute_ref_server.cpp
 +++ b/test/simple_execute_ref_server.cpp
 @@ -61,7 +61,7 @@ using namespace actionlib;
- 
+
  SimpleExecuteRefServer::SimpleExecuteRefServer()
  : as_(nh_, "reference_action", boost::bind(&SimpleExecuteRefServer::executeCallback, this,
 -    _1), false)

--- a/meta-ros1-noetic/recipes-bbappends/actionlib/actionlib_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/actionlib/actionlib_%.bbappend
@@ -11,3 +11,4 @@ RDEPENDS:${PN}:remove = "wxpython"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 SRC_URI += "file://0001-Fix-build-with-boost-1.73.0.patch"
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/angles/angles_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/angles/angles_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/bond-core/bond_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/bond-core/bond_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/bond-core/bondcpp_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/bond-core/bondcpp_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/bond-core/bondpy_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/bond-core/bondpy_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/catkin/catkin_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/catkin/catkin_%.bbappend
@@ -1,5 +1,7 @@
 # Copyright (c) 2019-2020 LG Electronics, Inc.
 
+LICENSE = "BSD-3-Clause"
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI += " \

--- a/meta-ros1-noetic/recipes-bbappends/class-loader/class-loader_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/class-loader/class-loader_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/cmake-modules/cmake-modules_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/cmake-modules/cmake-modules_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/common-msgs/actionlib-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/common-msgs/actionlib-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/common-msgs/diagnostic-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/common-msgs/diagnostic-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/common-msgs/geometry-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/common-msgs/geometry-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/common-msgs/nav-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/common-msgs/nav-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/common-msgs/sensor-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/common-msgs/sensor-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/common-msgs/trajectory-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/common-msgs/trajectory-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/common-msgs/visualization-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/common-msgs/visualization-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/diagnostics/diagnostic-aggregator_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/diagnostics/diagnostic-aggregator_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/diagnostics/diagnostic-updater_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/diagnostics/diagnostic-updater_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/diagnostics/self-test_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/diagnostics/self-test_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/driver-common/driver-base_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/driver-common/driver-base_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/dynamic-reconfigure/dynamic-reconfigure_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/dynamic-reconfigure/dynamic-reconfigure_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/gencpp/gencpp_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/gencpp/gencpp_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/genmsg/genmsg_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/genmsg/genmsg_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/genpy/genpy_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/genpy/genpy_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/geometry/tf_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/geometry/tf_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-geometry-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-geometry-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-kdl_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-kdl_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-py_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-py_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-ros_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-ros_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-sensor-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/geometry2/tf2-sensor-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/geometry2/tf2_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/geometry2/tf2_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/image-common/image-transport_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/image-common/image-transport_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/kdl-parser/kdl-parser_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/kdl-parser/kdl-parser_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/laser-geometry/laser-geometry_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/laser-geometry/laser-geometry_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/message-generation/message-generation_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/message-generation/message-generation_%.bbappend
@@ -1,5 +1,7 @@
 # Copyright (c) 2019-2020 LG Electronics, Inc.
 
+LICENSE = "BSD-3-Clause"
+
 # Not supporting Lisp => remove dependencies on geneus and genlisp
 do_configure:prepend() {
     sed -i -e '/^catkin_package(/ {; s/ geneus / /; s/ genlisp / /; }' ${S}/CMakeLists.txt

--- a/meta-ros1-noetic/recipes-bbappends/message-runtime/message-runtime_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/message-runtime/message-runtime_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/navigation-msgs/map-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/navigation-msgs/map-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/navigation-msgs/move-base-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/navigation-msgs/move-base-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/navigation/base-local-planner_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/navigation/base-local-planner_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/navigation/costmap-2d_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/navigation/costmap-2d_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/navigation/dwa-local-planner_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/navigation/dwa-local-planner_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/navigation/nav-core_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/navigation/nav-core_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/navigation/voxel-grid_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/navigation/voxel-grid_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/octomap/octomap_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/octomap/octomap_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/pluginlib/pluginlib_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/pluginlib/pluginlib_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/power-msgs/power-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/power-msgs/power-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/robot-state-publisher/robot-state-publisher_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/robot-state-publisher/robot-state-publisher_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm-msgs/rosgraph-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm-msgs/rosgraph-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm-msgs/std-srvs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm-msgs/std-srvs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/message-filters_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/message-filters_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rosbag-storage_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rosbag-storage_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rosbag_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rosbag_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/roscpp_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/roscpp_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rosgraph_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rosgraph_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/roslaunch_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/roslaunch_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/roslz4_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/roslz4_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rosmaster_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rosmaster_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rosmsg_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rosmsg_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rosnode_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rosnode_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rosout_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rosout_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rosparam_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rosparam_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rospy_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rospy_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rosservice_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rosservice_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rostest_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rostest_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/rostopic_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/rostopic_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/roswtf_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/roswtf_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros-comm/topic-tools_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros-comm/topic-tools_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros/mk_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/mk_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros/rosbash_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/rosbash_%.bbappend
@@ -1,5 +1,7 @@
 # Copyright (c) 2019 LG Electronics, Inc.
 
+LICENSE = "BSD-3-Clause"
+
 # "rosrun" uses array variables, so we can't use the BASH provided by "busybox" but must use a "real" one. NB. "busybox" is only
 # present on the target.
 do_install:append:class-target() {

--- a/meta-ros1-noetic/recipes-bbappends/ros/rosboost-cfg_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/rosboost-cfg_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros/rosbuild_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/rosbuild_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros/rosclean_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/rosclean_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros/roscreate_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/roscreate_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros/roslang_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/roslang_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros/roslib_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/roslib_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros/rosmake_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/rosmake_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/ros/rosunit_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/ros/rosunit_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/rosbag-migration-rule/rosbag-migration-rule_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/rosbag-migration-rule/rosbag-migration-rule_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/rosconsole-bridge/rosconsole-bridge_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/rosconsole-bridge/rosconsole-bridge_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/rosconsole/rosconsole_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/rosconsole/rosconsole_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/roscpp-core/cpp-common_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/roscpp-core/cpp-common_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/roscpp-core/roscpp-serialization_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/roscpp-core/roscpp-serialization_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/roscpp-core/roscpp-traits_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/roscpp-core/roscpp-traits_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/roscpp-core/rostime_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/roscpp-core/rostime_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/roslint/roslint_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/roslint/roslint_%.bbappend
@@ -1,5 +1,7 @@
 # Copyright (c) 2019 LG Electronics, Inc.
 
+LICENSE = "BSD-3-Clause"
+
 do_install:append:class-target() {
     # This testing script requires bash, which isn't always on the target.
     rm -f ${D}${ros_libdir}/${ROS_BPN}/test_wrapper

--- a/meta-ros1-noetic/recipes-bbappends/rospack/rospack_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/rospack/rospack_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/rosserial/rosserial-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/rosserial/rosserial-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/rosserial/rosserial-python_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/rosserial/rosserial-python_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/rosserial/rosserial-server_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/rosserial/rosserial-server_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/sick-scan-xd/sick-scan-xd_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/sick-scan-xd/sick-scan-xd_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0"

--- a/meta-ros1-noetic/recipes-bbappends/std-msgs/std-msgs_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/std-msgs/std-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/universal-robots/ur-description_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/universal-robots/ur-description_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/urdf/urdf-parser-plugin_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/urdf/urdf-parser-plugin_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1-noetic/recipes-bbappends/urdf/urdf_%.bbappend
+++ b/meta-ros1-noetic/recipes-bbappends/urdf/urdf_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros1/recipes-extended/console-bridge/console-bridge_0.4.2.bb
+++ b/meta-ros1/recipes-extended/console-bridge/console-bridge_0.4.2.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "console_bridge is a ROS-independent, pure CMake package that prov
 calls that mirror those found in rosconsole, but for applications that are not necessarily using \
 ROS."
 SECTION = "devel"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "\
     file://include/console_bridge/console.h;beginline=1;endline=33;md5=279eed49072cc9f6ebe38974afcc4803 \
     file://src/console.cpp;beginline=1;endline=33;md5=279eed49072cc9f6ebe38974afcc4803 \

--- a/meta-ros1/recipes-extended/urdfdom-headers/urdfdom-headers_1.0.0-1.bb
+++ b/meta-ros1/recipes-extended/urdfdom-headers/urdfdom-headers_1.0.0-1.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "The URDF (U-Robot Description Format) headers provides core \
 data structure headers for URDF."
 SECTION = "devel"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b441202ba2d6b14d62026cb18bb960ed"
 
 ROS_BPN = "urdfdom_headers"

--- a/meta-ros1/recipes-extended/urdfdom/urdfdom_1.0.0-2.bb
+++ b/meta-ros1/recipes-extended/urdfdom/urdfdom_1.0.0-2.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "The URDF (U-Robot Description Format) library provides core \
 data structures and a simple XML parsers for populating the class data \
 structures from an URDF file."
 SECTION = "devel"
-LICENSE = "BSD"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b441202ba2d6b14d62026cb18bb960ed"
 
 ROS_BPN = "urdfdom"

--- a/meta-ros2-humble/recipes-bbappends/ament-lint/ament-cpplint_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ament-lint/ament-cpplint_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/angles/angles_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/angles/angles_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/bond-core/bond-core_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/bond-core/bond-core_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/bond-core/bond_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/bond-core/bond_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/bond-core/bondcpp_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/bond-core/bondcpp_%.bbappend
@@ -1,3 +1,5 @@
 # Copyright (c) 2021 LG Electronics, Inc.
 
+LICENSE = "BSD-3-Clause"
+
 inherit pkgconfig

--- a/meta-ros2-humble/recipes-bbappends/class-loader/class-loader_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/class-loader/class-loader_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/common-interfaces/sensor-msgs-py_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/common-interfaces/sensor-msgs-py_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/console-bridge-vendor/console-bridge-vendor_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/console-bridge-vendor/console-bridge-vendor_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/eigen-stl-containers/eigen-stl-containers_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/eigen-stl-containers/eigen-stl-containers_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geographic-info/geographic-msgs_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geographic-info/geographic-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/geometry2_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/geometry2_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2-bullet_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2-bullet_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2-eigen-kdl_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2-eigen-kdl_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2-eigen_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2-eigen_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2-geometry-msgs_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2-geometry-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2-kdl_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2-kdl_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2-py_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2-py_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2-ros-py_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2-ros-py_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2-ros_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2-ros_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2-sensor-msgs_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2-sensor-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2-tools_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2-tools_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/geometry2/tf2_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/geometry2/tf2_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/googletest/gmock-vendor_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/googletest/gmock-vendor_%.bbappend
@@ -1,5 +1,7 @@
 # Copyright (c) 2019 LG Electronics, Inc.
 
+LICENSE = "BSD-3-Clause"
+
 do_install:append() {
     rm -rf ${D}${prefix}/src
 }

--- a/meta-ros2-humble/recipes-bbappends/googletest/gtest-vendor_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/googletest/gtest-vendor_%.bbappend
@@ -1,5 +1,7 @@
 # Copyright (c) 2019 LG Electronics, Inc.
 
+LICENSE = "BSD-3-Clause"
+
 do_install:append() {
     rm -rf ${D}${prefix}/src
 }

--- a/meta-ros2-humble/recipes-bbappends/hls-lfcd-lds-driver/hls-lfcd-lds-driver_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/hls-lfcd-lds-driver/hls-lfcd-lds-driver_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/image-common/image-transport_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/image-common/image-transport_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/interactive-markers/interactive-markers_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/interactive-markers/interactive-markers_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/kdl-parser/kdl-parser_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/kdl-parser/kdl-parser_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/laser-geometry/laser-geometry_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/laser-geometry/laser-geometry_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/launch/launch-testing-ament-cmake_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/launch/launch-testing-ament-cmake_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/mavros/libmavconn_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/mavros/libmavconn_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "GPL-3.0-only & LGPL-3.0-only & BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/mavros/mavros-msgs_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/mavros/mavros-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "GPL-3.0-only & LGPL-3.0-only & BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/mavros/mavros_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/mavros/mavros_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "GPL-3.0-only & LGPL-3.0-only & BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/message-filters/message-filters_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/message-filters/message-filters_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/navigation-msgs/map-msgs_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/navigation-msgs/map-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/off-highway-sensor-drivers/off-highway-can_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & MIT"

--- a/meta-ros2-humble/recipes-bbappends/ompl/ompl_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ompl/ompl_%.bbappend
@@ -1,5 +1,7 @@
 # Copyright (c) 2021 LG Electronics, Inc.
 
+LICENSE = "BSD-3-Clause"
+
 # used only as runtime dependency, but there is no ode/libode recipe, try to set it empty to test in runtime if this new dependency from 1.5.2 version is really mandatory
 # https://github.com/ompl/ompl/compare/1.5.1...1.5.2
 # https://github.com/ompl/ompl/commit/bb0a03c6fe4fbba0282c9a58881c3f499e7564d0 says it's optional

--- a/meta-ros2-humble/recipes-bbappends/orocos-kinematics-dynamics/orocos-kdl-vendor_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/orocos-kinematics-dynamics/orocos-kdl-vendor_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0"

--- a/meta-ros2-humble/recipes-bbappends/pcl-msgs/pcl-msgs_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/pcl-msgs/pcl-msgs_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/perception-pcl/pcl-conversions_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/perception-pcl/pcl-conversions_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/phidgets-drivers/libphidget22_2.3.3-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/phidgets-drivers/libphidget22_2.3.3-1.bbappend
@@ -3,7 +3,7 @@
 # WARNING: libphidget22-2.0.1-1-r0 do_populate_lic: libphidget22: No generic license file exists for: LGPL-2 in any provider
 # COPYING and COPYING.LESSER in libphidget22-1.4.20190605.tar.gz say GPL-3.0+ and LGPL-3.0+, source files have LGPL-3.0+
 # headers only autotools files are GPL-3.0+
-LICENSE = "LGPL-3.0+"
+LICENSE = "LGPL-3.0-or-later"
 
 DEPENDS += "${PN}-upstream"
 

--- a/meta-ros2-humble/recipes-bbappends/plotjuggler-ros/plotjuggler-ros_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/plotjuggler-ros/plotjuggler-ros_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "AGPL-3.0-only"

--- a/meta-ros2-humble/recipes-bbappends/pluginlib/pluginlib_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/pluginlib/pluginlib_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/pybind11-vendor/pybind11-vendor_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/pybind11-vendor/pybind11-vendor_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/python-qt-binding/python-qt-binding_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/python-qt-binding/python-qt-binding_%.bbappend
@@ -1,3 +1,4 @@
 # Copyright (c) 2023 Wind River Systems, Inc.
 
+LICENSE = "BSD-3-Clause"
 DEPENDS += "sip3-native python3-pyqt5-native"

--- a/meta-ros2-humble/recipes-bbappends/qt-gui-core/qt-gui_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/qt-gui-core/qt-gui_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/robot-state-publisher/robot-state-publisher_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/robot-state-publisher/robot-state-publisher_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/rosbag2/zstd-vendor/0001-CMakeLists.txt-prevent-building-zstd-with-ExternalPr.patch
+++ b/meta-ros2-humble/recipes-bbappends/rosbag2/zstd-vendor/0001-CMakeLists.txt-prevent-building-zstd-with-ExternalPr.patch
@@ -1,6 +1,6 @@
-From 1e0b46a476c1c950e22403a2d8950f5c97a1a0fe Mon Sep 17 00:00:00 2001
-From: Martin Jansa <martin.jansa@lge.com>
-Date: Fri, 5 Jun 2020 11:35:25 -0700
+From ec37b8a45ee6302b44654e3b46219b7eba0f6383 Mon Sep 17 00:00:00 2001
+From: Mikhail Rudenko <mike.rudenko@gmail.com>
+Date: Thu, 11 Jul 2024 01:25:22 +0300
 Subject: [PATCH] CMakeLists.txt: prevent building zstd with ExternalProject
 
 * use pkg-config, because zstd doesn't provide cmake find
@@ -13,26 +13,27 @@ Rebase patch on humble release.
 
 Signed-off-by: Sandeep Gundlupet Raju <sandeep.gundlupet-raju@amd.com>
 ---
- CMakeLists.txt                      | 54 +++--------------------------
+ CMakeLists.txt                      | 55 +++--------------------------
  cmake_minimum_required_2.8.12.patch | 26 --------------
- no_internal_headers.patch           | 27 ---------------
- 3 files changed, 4 insertions(+), 103 deletions(-)
+ no_internal_headers.patch           | 27 --------------
+ 3 files changed, 4 insertions(+), 104 deletions(-)
  delete mode 100644 cmake_minimum_required_2.8.12.patch
  delete mode 100644 no_internal_headers.patch
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index e3d4a22a0..fb0adec42 100644
+index da202fbef..b2143987a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -9,58 +9,12 @@ option(FORCE_BUILD_VENDOR_PKG
+@@ -11,59 +11,12 @@ option(FORCE_BUILD_VENDOR_PKG
    OFF)
- 
+
  if(NOT FORCE_BUILD_VENDOR_PKG)
--  find_package(zstd QUIET)
+-  # We need at least VERSION 1.4.4, version check is done in Findzstd.cmake
+-  find_package(zstd 1.4.4 QUIET)
 +  find_package(PkgConfig REQUIRED)
 +  pkg_check_modules(ZSTD REQUIRED libzstd>=1.4.4)
  endif()
- 
+
 -macro(build_zstd)
 -  set(extra_cmake_args)
 -
@@ -80,7 +81,7 @@ index e3d4a22a0..fb0adec42 100644
 -    USE_SOURCE_PERMISSIONS)
 -endmacro()
 -
--if (NOT zstd_FOUND OR "${zstd_VERSION}" VERSION_LESS 1.4.4)
+-if (NOT zstd_FOUND)
 -  build_zstd()
 +if (NOT ZSTD_FOUND OR "${ZSTD_VERSION}" VERSION_LESS 1.4.4)
 +  message(STATUS "Zstd not found, missing dependency or version less than 1.4.4, found ${ZSTD_VERSION}")

--- a/meta-ros2-humble/recipes-bbappends/rosbag2/zstd-vendor_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/rosbag2/zstd-vendor_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/rqt-runtime-monitor/rqt-runtime-monitor_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/rqt-runtime-monitor/rqt-runtime-monitor_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/rqt/rqt-gui-py_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/rqt/rqt-gui-py_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/rqt/rqt-gui_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/rqt/rqt-gui_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/slam-toolbox/slam-toolbox_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/slam-toolbox/slam-toolbox_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "LGPL-2.1-only"

--- a/meta-ros2-humble/recipes-bbappends/unique-identifier-msgs/unique-identifier-msgs_2.2.1-3.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/unique-identifier-msgs/unique-identifier-msgs_2.2.1-3.bbappend
@@ -1,5 +1,7 @@
 # Copyright (c) 2020 LG Electronics, Inc.
 
+LICENSE = "BSD-3-Clause"
+
 # Without the target dependencies, ament finds the native packages and then fails to link (error: incompatible target).
 ROS_BUILD_DEPENDS += " \
     rosidl-default-runtime \

--- a/meta-ros2-humble/recipes-bbappends/urdf/urdf-parser-plugin_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/urdf/urdf-parser-plugin_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/urdf/urdf_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/urdf/urdf_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/urdfdom-headers/urdfdom-headers_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/urdfdom-headers/urdfdom-headers_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/urdfdom/urdfdom_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/urdfdom/urdfdom_%.bbappend
@@ -1,3 +1,5 @@
 # Copyright (c) 2020 LG Electronics, Inc.
 
+LICENSE = "BSD-3-Clause"
+
 inherit ros_insane_dev_so

--- a/meta-ros2-humble/recipes-bbappends/vision-opencv/cv-bridge_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/vision-opencv/cv-bridge_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/vision-opencv/image-geometry_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/vision-opencv/image-geometry_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"

--- a/meta-ros2-humble/recipes-bbappends/vision-opencv/vision-opencv_%.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/vision-opencv/vision-opencv_%.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"


### PR DESCRIPTION
Update two patches and fix a few license-related QA warnings (mostly about `LICENSE = "BSD"`) for `noetic` and `humble`.