### PR TITLE
Enable SDK for ROS2 Rolling

### DIFF
--- a/meta-ros-common/classes/ros_cmake.bbclass
+++ b/meta-ros-common/classes/ros_cmake.bbclass
@@ -3,7 +3,7 @@
 
 inherit cmake
 
-EXTRA_OECMAKE:prepend = "\
+EXTRA_OECMAKE:prepend:class-target = "\
     -DCMAKE_PREFIX_PATH='${STAGING_DIR_HOST}${ros_prefix};${STAGING_DIR_HOST}${prefix}' \
     -DCMAKE_INSTALL_PREFIX:PATH='${ros_prefix}' \
     -DCMAKE_MODULE_PATH='${STAGING_DIR_HOST}${ros_datadir}/cmake/Modules/' \
@@ -11,5 +11,10 @@ EXTRA_OECMAKE:prepend = "\
 
 EXTRA_OECMAKE:prepend:class-native = "\
     -DCMAKE_PREFIX_PATH='${STAGING_DIR_NATIVE}${ros_prefix};${STAGING_DIR_NATIVE}${prefix}' \
+    -DCMAKE_INSTALL_PREFIX:PATH='${ros_prefix}' \
+"
+
+EXTRA_OECMAKE:prepend:class-nativesdk = "\
+    -DCMAKE_PREFIX_PATH='${STAGING_DIR_NATIVE}/opt/ros/${ROS_DISTRO};${STAGING_DIR_NATIVE}${ros_prefix};${STAGING_DIR_NATIVE}${prefix}' \
     -DCMAKE_INSTALL_PREFIX:PATH='${ros_prefix}' \
 "

--- a/meta-ros-common/recipes-core/images/ros2-image-sdktest.bb
+++ b/meta-ros-common/recipes-core/images/ros2-image-sdktest.bb
@@ -1,0 +1,78 @@
+SUMMARY = "ROS2 SDK Image"
+DESCRIPTION = "${SUMMARY}"
+
+inherit core-image
+inherit ros_distro_${ROS_DISTRO}
+inherit ${ROS_DISTRO_TYPE}_image
+
+IMAGE_FEATURES:append = " \
+"
+
+IMAGE_INSTALL:append = " \
+    packagegroup-core-boot \
+    ${CORE_IMAGE_EXTRA_INSTALL} \
+"
+
+inherit core-image
+inherit ros_distro_${ROS_DISTRO}
+inherit ${ROS_DISTRO_TYPE}_image
+
+TOOLCHAIN_HOST_TASK:append = " \
+    nativesdk-ament-package \
+    nativesdk-python3-colcon-common-extensions \
+    nativesdk-python3-numpy \
+    nativesdk-rosidl-adapter \
+    nativesdk-rosidl-cli \
+    nativesdk-rosidl-cmake \
+    nativesdk-rosidl-default-generators \
+    nativesdk-rosidl-generator-c \
+    nativesdk-rosidl-generator-cpp \
+    nativesdk-rosidl-parser \
+    nativesdk-rosidl-typesupport-c \
+    nativesdk-rosidl-typesupport-cpp \
+    nativesdk-rosidl-typesupport-fastrtps-c \
+    nativesdk-rosidl-typesupport-fastrtps-cpp \
+    nativesdk-rosidl-typesupport-introspection-c \
+    nativesdk-rosidl-typesupport-introspection-cpp \
+"
+
+TOOLCHAIN_TARGET_TASK:append = " \
+    ament-package \
+    ament-cmake \
+    ament-cmake-auto \
+    ament-cmake-core \
+    ament-cmake-export-definitions \
+    ament-cmake-export-dependencies \
+    ament-cmake-export-include-directories \
+    ament-cmake-export-interfaces \
+    ament-cmake-export-libraries \
+    ament-cmake-export-link-flags \
+    ament-cmake-export-targets \
+    ament-cmake-gmock \
+    ament-cmake-gtest \
+    ament-cmake-include-directories \
+    ament-cmake-libraries \
+    ament-cmake-pytest \
+    ament-cmake-python \
+    ament-cmake-ros \
+    ament-cmake-target-dependencies \
+    ament-cmake-test \
+    ament-cmake-version \
+    ament-cmake-gen-version-h \
+    ament-lint-auto \
+    foonathan-memory-staticdev \
+    \
+    nav-msgs \
+    sensor-msgs \
+    rclcpp \
+    rclcpp-lifecycle \
+    rclcpp-action \
+    rclcpp-components \
+    builtin-interfaces \
+    fastrtps-cmake-module \
+    rosidl-default-generators \
+    rosidl-core-generators \
+    rosidl-cmake \
+    \
+    ros-workspace \
+"

--- a/meta-ros-common/recipes-devtools/colcon/python3-colcon-core/0003-Force-shebang-to-usr-bin-env-python3.patch
+++ b/meta-ros-common/recipes-devtools/colcon/python3-colcon-core/0003-Force-shebang-to-usr-bin-env-python3.patch
@@ -1,0 +1,13 @@
+diff --git a/colcon_core/task/python/build.py b/colcon_core/task/python/build.py
+index 7181d20..eb82058 100644
+--- a/colcon_core/task/python/build.py
++++ b/colcon_core/task/python/build.py
+@@ -73,7 +73,7 @@ class PythonBuildTask(TaskExtensionPoint):
+                     os.path.realpath(args.build_base),
+                     os.path.realpath(args.path)),
+                 'build', '--build-base', os.path.join(
+-                    args.build_base, 'build'),
++                    args.build_base, 'build'), '--executable', '/usr/bin/env python3',
+                 'install', '--prefix', args.install_base,
+                 '--record', os.path.join(args.build_base, 'install.log'),
+                 # prevent installation of dependencies specified in setup.py

--- a/meta-ros-common/recipes-devtools/colcon/python3-colcon-core_0.6.1.bb
+++ b/meta-ros-common/recipes-devtools/colcon/python3-colcon-core_0.6.1.bb
@@ -6,6 +6,7 @@ LIC_FILES_CHKSUM = "file://setup.cfg;beginline=22;endline=22;md5=3d0bd1ac53c1dd5
 
 SRC_URI += "file://0001-Remove-optional-pytest-dependencies.patch \
            file://0002-Fix-regression-when-enitre-workspace-is-symlinked.patch \
+           file://0003-Force-shebang-to-usr-bin-env-python3.patch \
            "
 SRC_URI[sha256sum] = "fc14534b2ce745fcc332afc0bb0ddf3e45d5d69c15da15b9471cfb7b0b9edbe9"
 

--- a/meta-ros-common/recipes-devtools/python/python3-coloredlogs_%.bbappend
+++ b/meta-ros-common/recipes-devtools/python/python3-coloredlogs_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND += "nativesdk"

--- a/meta-ros-common/recipes-devtools/python/python3-dateutil_%.bbappend
+++ b/meta-ros-common/recipes-devtools/python/python3-dateutil_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND += "nativesdk"

--- a/meta-ros-common/recipes-devtools/python/python3-docutils_%.bbappend
+++ b/meta-ros-common/recipes-devtools/python/python3-docutils_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND += "nativesdk"

--- a/meta-ros-common/recipes-devtools/python/python3-humanfriendly_%.bbappend
+++ b/meta-ros-common/recipes-devtools/python/python3-humanfriendly_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND += "nativesdk"

--- a/meta-ros-common/recipes-devtools/python/python3-lark-parser_0.7.0.bb
+++ b/meta-ros-common/recipes-devtools/python/python3-lark-parser_0.7.0.bb
@@ -5,3 +5,5 @@
 require python-lark-parser.inc
 
 inherit setuptools3
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros-common/recipes-support/asio/asio_%.bbappend
+++ b/meta-ros-common/recipes-support/asio/asio_%.bbappend
@@ -1,3 +1,3 @@
 # Copyright (c) 2019-2020 LG Electronics, Inc.
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros-common/recipes-support/libtinyxml2/libtinyxml2_%.bbappend
+++ b/meta-ros-common/recipes-support/libtinyxml2/libtinyxml2_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND += "nativesdk"

--- a/meta-ros2-rolling/recipes-bbappends/fastrtps/fastrtps/0001-FindTinyXML2.cmake-fix-find_library-libtinyxml2.patch
+++ b/meta-ros2-rolling/recipes-bbappends/fastrtps/fastrtps/0001-FindTinyXML2.cmake-fix-find_library-libtinyxml2.patch
@@ -1,0 +1,16 @@
+diff --git a/cmake/modules/FindTinyXML2.cmake b/cmake/modules/FindTinyXML2.cmake
+index 44b8e645..ba964578 100644
+--- a/cmake/modules/FindTinyXML2.cmake
++++ b/cmake/modules/FindTinyXML2.cmake
+@@ -39,7 +39,10 @@ else()
+     if(TINYXML2_FROM_SOURCE)
+         find_path(TINYXML2_SOURCE_DIR NAMES tinyxml2.cpp NO_CMAKE_FIND_ROOT_PATH)
+     else()
+-        find_library(TINYXML2_LIBRARY tinyxml2)
++        find_library(TINYXML2_LIBRARIES tinyxml2)
++        add_library(tinyxml2 SHARED IMPORTED)
++        set_property(TARGET tinyxml2 APPEND PROPERTY IMPORTED_LOCATION "${TINYXML2_LIBRARIES}")
++        set(TINYXML2_LIBRARY tinyxml2)
+     endif()
+
+     include(FindPackageHandleStandardArgs)

--- a/meta-ros2-rolling/recipes-bbappends/fastrtps/fastrtps_%.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/fastrtps/fastrtps_%.bbappend
@@ -22,3 +22,6 @@ EXTRA_OECMAKE += " -DSM_RUN_RESULT=0 -DSM_RUN_RESULT__TRYRUN_OUTPUT=PTHREAD_RWLO
 sysroot_stage_all:append() {
     sysroot_stage_dir ${D}${bindir} ${SYSROOT_DESTDIR}${bindir}
 }
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://0001-FindTinyXML2.cmake-fix-find_library-libtinyxml2.patch"

--- a/meta-ros2/classes/ros_ament_cmake.bbclass
+++ b/meta-ros2/classes/ros_ament_cmake.bbclass
@@ -25,7 +25,7 @@ export AMENT_PREFIX_PATH="${STAGING_DIR_HOST}${prefix};${STAGING_DIR_NATIVE}${pr
 
 inherit cmake python3native
 
-PYTHONPATH:prepend:class-nativesdk = "${STAGING_DIR_NATIVE}/opt/ros/${ROS_DISTRO}/lib/python3.12/site-packages:"
+PYTHONPATH:prepend:class-nativesdk = "${STAGING_DIR_NATIVE}/opt/ros/${ROS_DISTRO}/lib/python${PYTHON_BASEVERSION}/site-packages:"
 
 FILES:${PN}:prepend = " \
     ${datadir}/ament_index \

--- a/meta-ros2/classes/ros_ament_cmake.bbclass
+++ b/meta-ros2/classes/ros_ament_cmake.bbclass
@@ -25,16 +25,23 @@ export AMENT_PREFIX_PATH="${STAGING_DIR_HOST}${prefix};${STAGING_DIR_NATIVE}${pr
 
 inherit cmake python3native
 
+PYTHONPATH:prepend:class-nativesdk = "${STAGING_DIR_NATIVE}/opt/ros/${ROS_DISTRO}/lib/python3.12/site-packages:"
+
 FILES:${PN}:prepend = " \
     ${datadir}/ament_index \
 "
 
-EXTRA_OECMAKE:prepend = "\
+EXTRA_OECMAKE:prepend:class-target = "\
     -DCMAKE_PREFIX_PATH='${STAGING_DIR_HOST}${ros_prefix};${STAGING_DIR_HOST}${prefix}' \
     -DCMAKE_INSTALL_PREFIX:PATH='${ros_prefix}' \
 "
 
 EXTRA_OECMAKE:prepend:class-native = "\
     -DCMAKE_PREFIX_PATH='${ros_prefix}' \
+    -DCMAKE_INSTALL_PREFIX:PATH='${ros_prefix}' \
+"
+
+EXTRA_OECMAKE:prepend:class-nativesdk = "\
+    -DCMAKE_PREFIX_PATH='${STAGING_DIR_NATIVE}/opt/ros/${ROS_DISTRO};${STAGING_DIR_NATIVE}${ros_prefix};${STAGING_DIR_NATIVE}${prefix}' \
     -DCMAKE_INSTALL_PREFIX:PATH='${ros_prefix}' \
 "


### PR DESCRIPTION
This PR tries to resurrect PR #988 for Rolling to enable OpenEmbedded SDK cross-compilation.  These changes allow [demos](https://github.com/ros2/demos), [examples](https://github.com/ros2/examples) and [examples_interfaces](https://github.com/ros2/example_interfaces) packages to be built using the resulting SDK.  To build the SDK use:

```
$ bitbake ros2-image-sdktest -c do_populate_sdk
```
Install the resulting SDK, setup a ROS2 workspace containing demos, examples and example_interfaces and build the workspace using the follow script:

```
export ROS_VERSION=2
export ROS_PYTHON_VERSION=3
export ROS_AUTOMATIC_DISCOVERY_RANGE=SUBNET
export ROS_DISTRO=rolling
export PYTHONPATH=$OECORE_NATIVE_SYSROOT/usr/lib/python3.12/site-packages:$OECORE_TARGET_SYSROOT/opt/ros/rolling/lib/python3.12/site-packages
export AMENT_PREFIX_PATH=$OECORE_TARGET_SYSROOT/opt/ros/rolling
usr/share:$OECORE_TARGET_SYSROOT/opt/ros/rolling/share:$OECORE_TARGET_SYSROOT/opt/ros/rolling/lib/cmake"

colcon build \
--merge-install \
--install-base $PWD/install/arm64 \
--cmake-args \
" -DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE" \
" -DCMAKE_STAGING_PREFIX=$PWD/install/arm64" \
" -DBUILD_TESTING=OFF"
```
Install the $PWD/install/arm64 on the target device. Setup the device workspace:
```
$ . /opt/ros/rolling/setup.bash
$ . ./arm64/local_setup.bash
```
Run any of the rclcpp examples to demonstrate the valid cross-compilation. 