### PR TITLE
{jazzy}: add bbappend to fix dependency issue of liblz4-vendor

### DIFF
--- a/meta-ros2-jazzy/recipes-bbappends/rosbag2/liblz4-vendor_0.26.1-2.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/rosbag2/liblz4-vendor_0.26.1-2.bbappend
@@ -1,0 +1,7 @@
+#Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+
+DEPENDS:remove = "${ROS_UNRESOLVED_DEP-liblz4-dev}"
+RDEPENDS:${PN}:remove = "${ROS_UNRESOLVED_DEP-liblz4}"
+
+DEPENDS:append = "lz4"
+RDEPENDS:${PN}:append = "lz4"


### PR DESCRIPTION
lz4 is provided by poky. And it provides: liblz4 and liblz4-dev. Error:
ERROR: Nothing PROVIDES 'ROS_UNRESOLVED_DEP-liblz4-dev'
/local/mnt/workspace/jiaxshi/projects/ros_poky/meta-ros/meta-ros2-jazzy/generated-recipes/rosbag2/liblz4-vendor_0.26.1-2.bb DEPENDS on or otherwise requires it)