### PR TITLE
{jazzy}: set prefer version for yaml-cpp

### DIFF
--- a/meta-ros2-jazzy/conf/ros-distro/include/jazzy/ros-distro-preferred-versions.inc
+++ b/meta-ros2-jazzy/conf/ros-distro/include/jazzy/ros-distro-preferred-versions.inc
@@ -10,3 +10,4 @@
 # This is necessary as with ROS1 many recipes fail to build
 # as documented in https://github.com/ros/meta-ros/pull/936
 PREFERRED_VERSION_pcl = "1.13.0+git"
+PREFERRED_VERSION_yaml-cpp = "0.8.0"


### PR DESCRIPTION
Since yaml-cpp-vendor depends on yaml-cpp v0.8.0, v0.8.0 is needed by jazzy.

yaml-cpp 0.6.2 is provided in meta-ros layer.
yaml-cpp 0.8.0 is provided by meta-openembedded.


Not sure if yaml-cpp 0.6.2 is used by ROS1 or other distros, so keep it.