### PR TITLE
Scarthgap build failures

### DIFF
--- a/meta-ros2-jazzy/recipes-bbappends/demos/action-tutorials-interfaces_0.33.2-2.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/demos/action-tutorials-interfaces_0.33.2-2.bbappend
@@ -14,6 +14,7 @@ ROS_BUILDTOOL_DEPENDS += " \
 ROS_BUILD_DEPENDS += " \
     rosidl-typesupport-c \
     rosidl-typesupport-cpp \
+    action-msgs \
 "
 
 ROS_EXEC_DEPENDS += " \

--- a/meta-ros2-jazzy/recipes-bbappends/example-interfaces/example-interfaces_0.12.0-3.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/example-interfaces/example-interfaces_0.12.0-3.bbappend
@@ -14,6 +14,7 @@ ROS_BUILDTOOL_DEPENDS += " \
 ROS_BUILD_DEPENDS += " \
     rosidl-typesupport-c \
     rosidl-typesupport-cpp \
+    action-msgs \
 "
 
 ROS_EXEC_DEPENDS += " \

--- a/meta-ros2-jazzy/recipes-bbappends/image-transport-plugins/compressed-depth-image-transport_4.0.0-2.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/image-transport-plugins/compressed-depth-image-transport_4.0.0-2.bbappend
@@ -1,0 +1,8 @@
+#Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+
+#warning: unused parameter 'message_info' [-Wunused-parameter]
+CXXFLAGS += "-Wno-error=unused-parameter"
+
+#error: format not a string literal and no format arguments [-Werror=format-security]
+CXXFLAGS += " -Wno-format-security"
+


### PR DESCRIPTION
Build failures for some packages:
- libaction_msgs__rosidl_generator_c.so: error adding symbols: file in wrong format
- error: format not a string literal and no format arguments [-Werror=format-security]
- warning: unused parameter 'message_info' [-Wunused-parameter]
