### PR TITLE
ROS2 support in standard SDK

### DIFF
--- a/meta-ros-common/recipes-devtools/python/python-lark-parser.inc
+++ b/meta-ros-common/recipes-devtools/python/python-lark-parser.inc
@@ -9,4 +9,4 @@ SRC_URI[sha256sum] = "f2d5ee2f90aa28d3f4034c30af7a0561a7e9860e911dba4f35faa440a3
 
 inherit pypi
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros2/conf/distro/include/ros2-sdk.inc
+++ b/meta-ros2/conf/distro/include/ros2-sdk.inc
@@ -1,0 +1,49 @@
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved
+
+# native packages in SDK
+TOOLCHAIN_HOST_TASK:append = " \
+    nativesdk-ament-package \
+    nativesdk-python3-colcon-common-extensions \
+    nativesdk-python3-numpy \
+    nativesdk-rosidl-adapter \
+    nativesdk-rosidl-cli \
+    nativesdk-rosidl-cmake \
+    nativesdk-rosidl-generator-c \
+    nativesdk-rosidl-generator-cpp \
+    nativesdk-rosidl-parser \
+    nativesdk-rosidl-typesupport-c \
+    nativesdk-rosidl-typesupport-cpp \
+    nativesdk-rosidl-typesupport-fastrtps-c \
+    nativesdk-rosidl-typesupport-fastrtps-cpp \
+    nativesdk-rosidl-typesupport-introspection-c \
+    nativesdk-rosidl-typesupport-introspection-cpp \
+"
+
+# target packages in SDK
+TOOLCHAIN_TARGET_TASK:append = " \
+    ament-cmake \
+    ament-cmake-auto \
+    ament-cmake-core \
+    ament-cmake-export-definitions \
+    ament-cmake-export-dependencies \
+    ament-cmake-export-include-directories \
+    ament-cmake-export-interfaces \
+    ament-cmake-export-libraries \
+    ament-cmake-export-link-flags \
+    ament-cmake-export-targets \
+    ament-cmake-gen-version-h \
+    ament-cmake-gmock \
+    ament-cmake-google-benchmark \
+    ament-cmake-gtest \
+    ament-cmake-include-directories \
+    ament-cmake-libraries \
+    ament-cmake-nose \
+    ament-cmake-pytest \
+    ament-cmake-python \
+    ament-cmake-ros \
+    ament-cmake-target-dependencies \
+    ament-cmake-test \
+    ament-cmake-version \
+    ament-lint-auto \
+    foonathan-memory-staticdev \
+"

--- a/meta-ros2/conf/layer.conf
+++ b/meta-ros2/conf/layer.conf
@@ -23,3 +23,5 @@ LAYERDEPENDS_ros2-layer = " \
 LAYERSERIES_COMPAT_ros2-layer = "${ROS_OE_RELEASE_SERIES}"
 
 ROS_OE_DISTRO_NAME ?= "Robot Operating System 2 (ROS 2)"
+
+require conf/distro/include/ros2-sdk.inc


### PR DESCRIPTION
ROS2 support in standard SDK.
Refer to #988 

# Generate SDK
```
bitbake xxx-image -c populate_sdk
For example:
bitbake ros-image-core -c populate_sdk
```

# Build ROS package
Set up SDK env before below steps.

## ROS env set up
```
export AMENT_PREFIX_PATH="${OECORE_NATIVE_SYSROOT}/usr:${OECORE_TARGET_SYSROOT}/usr"

export PYTHONPATH=${OECORE_NATIVE_SYSROOT}/usr/lib/python3.10/site-packages/:${OECORE_TARGET_SYSROOT}/usr/lib/python3.10/site-packages/

colcon build --cmake-args -DCMAKE_TOOLCHAIN_FILE=${OE_CMAKE_TOOLCHAIN_FILE} \
-DBUILD_TESTING=OFF \
-DCMAKE_MAKE_PROGRAM=/usr/bin/make \
-DPYTHON_SOABI=cpython-310-aarch64-linux-gnu
```

## Build examples
```
git clone https://github.com/ros2/examples.git -b humble
cd examples
git clone https://github.com/ros2/example_interfaces.git -b humble

colcon build --cmake-args -DCMAKE_TOOLCHAIN_FILE=${OE_CMAKE_TOOLCHAIN_FILE} \
-DBUILD_TESTING=OFF \
-DCMAKE_MAKE_PROGRAM=/usr/bin/make \
-DPYTHON_SOABI=cpython-310-aarch64-linux-gnu
```
```
---
Finished <<< examples_rclcpp_wait_set [32.5s]

Summary: 23 packages finished [1min 12s]
```


# Issues
A discussion is created for discussing ROS support in SDK #1204 
## Build warning: stderr: python setup.py install is deprecated
```
--- stderr: examples_rclpy_minimal_client
/local/mnt3/workspace/jiaxshi/projects/sdk/ws4/sysroots/x86_64-qcomsdk-linux/usr/lib/python3.10/site-packages/setuptools/command/instal
l.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
```

## host path is included 
### setup script
```
vi install/setup.sh
 _colcon_prefix_chain_sh_COLCON_CURRENT_PREFIX=/local/mnt3/workspace/jiaxshi/projects/sdk/ws4/examples/install

```

###python shebang
```
vi install/examples_rclpy_executors/lib/examples_rclpy_executors/talker
 1 #!/local/mnt3/workspace/jiaxshi/projects/sdk/ws4/sysroots/x86_64-qcomsdk-linux/usr/bin/python3
  2 # EASY-INSTALL-ENTRY-SCRIPT: 'examples-rclpy-executors==0.15.1','console_scripts','talker'

```
