### PR TITLE
{common} Add images for ros_base and perception

### DIFF
--- a/meta-ros-common/recipes-core/images/ros-image-base.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-base.bb
@@ -1,0 +1,11 @@
+require ${COREBASE}/meta/recipes-core/images/core-image-minimal.bb
+
+SUMMARY = "A small image just capable of starting base ROS."
+DESCRIPTION = "${SUMMARY}"
+
+inherit ros_distro_${ROS_DISTRO}
+inherit ${ROS_DISTRO_TYPE}_image
+
+IMAGE_INSTALL:append = " \
+    ros-base \
+"

--- a/meta-ros-common/recipes-core/images/ros-image-perception.bb
+++ b/meta-ros-common/recipes-core/images/ros-image-perception.bb
@@ -1,0 +1,11 @@
+require ${COREBASE}/meta/recipes-core/images/core-image-minimal.bb
+
+SUMMARY = "A small image just capable of starting core ROS."
+DESCRIPTION = "${SUMMARY}"
+
+inherit ros_distro_${ROS_DISTRO}
+inherit ${ROS_DISTRO_TYPE}_image
+
+IMAGE_INSTALL:append = " \
+    perception \
+"


### PR DESCRIPTION
Simple PR to add two addition images. One to build the ros_base variant and the other to build the perception variant.