### PR TITLE
{rolling,jazzy} Teach image_proc to use new Aruco API

### DIFF
--- a/meta-ros2-jazzy/conf/ros-distro/include/jazzy/ros-distro.inc
+++ b/meta-ros2-jazzy/conf/ros-distro/include/jazzy/ros-distro.inc
@@ -389,3 +389,6 @@ ROS_UNRESOLVED_DEP-libavdevice-dev = "ffmpeg"
 
 ROS_UNRESOLVED_DEP-liblz4-dev = "lz4"
 ROS_UNRESOLVED_DEP-liblz4 = "lz4"
+
+ROS_UNRESOLVED_DEP-python3-semver = "python3-semver"
+ROS_UNRESOLVED_DEP-python3-deprecated = "python3-deprecated"

--- a/meta-ros2-jazzy/recipes-bbappends/image-pipeline/image-proc/0001-use-new-aruco-api.patch
+++ b/meta-ros2-jazzy/recipes-bbappends/image-pipeline/image-proc/0001-use-new-aruco-api.patch
@@ -1,0 +1,31 @@
+New API for Aruco in OpenCV
+
+Use the new API present in OpenCV 4.x for accessing aruco::DetectorParameters.
+
+Upstream-Status: Pending
+
+Signed-off-by: Rob Woolley <rob.woolley@windriver.com>
+
+diff --git a/src/track_marker.cpp b/src/track_marker.cpp
+index c0586e47..b396a3ee 100644
+--- a/src/track_marker.cpp
++++ b/src/track_marker.cpp
+@@ -64,8 +64,17 @@ TrackMarkerNode::TrackMarkerNode(const rclcpp::NodeOptions & options)
+   // Default dictionary is cv::aruco::DICT_6X6_250
+   int dict_id = this->declare_parameter("dictionary", 10);
+
++  #if CV_VERSION_MAJOR > 4 || CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR >= 7
++  detector_params_ = cv::makePtr<cv::aruco::DetectorParameters>();
++  #else
+   detector_params_ = cv::aruco::DetectorParameters::create();
++  #endif
++
++  #if CV_VERSION_MAJOR > 4 || CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR >= 7
++  dictionary_ = cv::makePtr<cv::aruco::Dictionary>(cv::aruco::getPredefinedDictionary(dict_id));
++  #else
+   dictionary_ = cv::aruco::getPredefinedDictionary(dict_id);
++  #endif
+
+   // Setup lazy subscriber using publisher connection callback
+   rclcpp::PublisherOptions pub_options;
+

--- a/meta-ros2-jazzy/recipes-bbappends/image-pipeline/image-proc_%.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/image-pipeline/image-proc_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://0001-use-new-aruco-api.patch"

--- a/meta-ros2-rolling/conf/ros-distro/include/rolling/ros-distro.inc
+++ b/meta-ros2-rolling/conf/ros-distro/include/rolling/ros-distro.inc
@@ -386,3 +386,6 @@ ROS_UNRESOLVED_DEP-libgdal-dev = "gdal"
 ROS_UNRESOLVED_DEP-python3-smbus = "python3-smbus"
 ROS_UNRESOLVED_DEP-libxkbcommon-dev = "libxkbcommon"
 ROS_UNRESOLVED_DEP-libavdevice-dev = "ffmpeg"
+
+ROS_UNRESOLVED_DEP-python3-semver = "python3-semver"
+ROS_UNRESOLVED_DEP-python3-deprecated = "python3-deprecated"

--- a/meta-ros2-rolling/recipes-bbappends/image-pipeline/image-proc/0001-use-new-aruco-api.patch
+++ b/meta-ros2-rolling/recipes-bbappends/image-pipeline/image-proc/0001-use-new-aruco-api.patch
@@ -1,0 +1,31 @@
+New API for Aruco in OpenCV
+
+Use the new API present in OpenCV 4.x for accessing aruco::DetectorParameters.
+
+Upstream-Status: Pending
+
+Signed-off-by: Rob Woolley <rob.woolley@windriver.com>
+
+diff --git a/src/track_marker.cpp b/src/track_marker.cpp
+index c0586e47..b396a3ee 100644
+--- a/src/track_marker.cpp
++++ b/src/track_marker.cpp
+@@ -64,8 +64,17 @@ TrackMarkerNode::TrackMarkerNode(const rclcpp::NodeOptions & options)
+   // Default dictionary is cv::aruco::DICT_6X6_250
+   int dict_id = this->declare_parameter("dictionary", 10);
+
++  #if CV_VERSION_MAJOR > 4 || CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR >= 7
++  detector_params_ = cv::makePtr<cv::aruco::DetectorParameters>();
++  #else
+   detector_params_ = cv::aruco::DetectorParameters::create();
++  #endif
++
++  #if CV_VERSION_MAJOR > 4 || CV_VERSION_MAJOR == 4 && CV_VERSION_MINOR >= 7
++  dictionary_ = cv::makePtr<cv::aruco::Dictionary>(cv::aruco::getPredefinedDictionary(dict_id));
++  #else
+   dictionary_ = cv::aruco::getPredefinedDictionary(dict_id);
++  #endif
+
+   // Setup lazy subscriber using publisher connection callback
+   rclcpp::PublisherOptions pub_options;
+

--- a/meta-ros2-rolling/recipes-bbappends/image-pipeline/image-proc_%.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/image-pipeline/image-proc_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+SRC_URI += "file://0001-use-new-aruco-api.patch"


### PR DESCRIPTION
This PR patches image-proc to conditionally use the new Aruco DetectorParamers API in opencv 4.7 or later.  The PR also add python3-sesmver and python3-deprecated to the ROS2 dependencies allowing the ROS2 perception variant to build.  