### PR TITLE
{common}: add license map to fix BSD license issue

### DIFF
--- a/meta-ros-common/conf/ros-distro/ros-distro.conf
+++ b/meta-ros-common/conf/ros-distro/ros-distro.conf
@@ -53,3 +53,5 @@ BBMASK:append = " ${@bb.utils.contains('BBFILE_COLLECTIONS', 'raspberrypi', '', 
 require conf/ros-distro/include/enable-fortran.inc
 
 require conf/ros-distro/include/ros-world-recipe-blacklist.inc
+
+SPDXLICENSEMAP[BSD] = "BSD-3-Clause"


### PR DESCRIPTION
Since BSD file was removed in YOCTO/scarthgap, some ROS recipes build failed due to cannot find BSD license.

Map BSD to BSD-3-Clause similar to YOCTO/kirkstone.

Fix issue #1208 

@robwoolley  Could you please review and check if this change is fine to merge?