### PR TITLE
{rolling} Make perception compile on Styhead

### DIFF
--- a/meta-ros-common/recipes-bbappends/gcc/libgfortran_14.2.bbappend
+++ b/meta-ros-common/recipes-bbappends/gcc/libgfortran_14.2.bbappend
@@ -1,0 +1,2 @@
+export GFORTRAN = "${FC} -fcanon-prefix-map -fdebug-prefix-map=${S}=${TARGET_DBGSRC_DIR} -fdebug-prefix-map=${B}=${TARGET_DBGSRC_DIR} -gno-record-gcc-switches"
+

--- a/meta-ros2-rolling/recipes-bbappends/laser-geometry/laser-geometry/0001-Remove-unneeded-Eigen3_INCLUDE_DIRS.patch
+++ b/meta-ros2-rolling/recipes-bbappends/laser-geometry/laser-geometry/0001-Remove-unneeded-Eigen3_INCLUDE_DIRS.patch
@@ -1,0 +1,24 @@
+From aab625410af5d0b52bc6f5aff30cd60c2026ba3f Mon Sep 17 00:00:00 2001
+From: Stephen Street <stephen@redrocketcomputing.com>
+Date: Fri, 22 Nov 2024 15:18:54 -0800
+Subject: [PATCH] Remove unneeded Eigen3_INCLUDE_DIRS
+
+Upstream-Status: Pending
+
+Signed-off-by: Stephen Street <stephen@redrocketcomputing.com>
+---
+ CMakeLists.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7cfcd03..cad8094 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -22,7 +22,6 @@ target_include_directories(laser_geometry
+   PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+     $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+-  ${Eigen3_INCLUDE_DIRS}
+ )
+ target_link_libraries(laser_geometry PUBLIC
+   ${sensor_msgs_TARGETS}

--- a/meta-ros2-rolling/recipes-bbappends/laser-geometry/laser-geometry_2.8.0-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/laser-geometry/laser-geometry_2.8.0-1.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Remove-unneeded-Eigen3_INCLUDE_DIRS.patch"

--- a/meta-ros2-rolling/recipes-bbappends/perception-pcl/pcl-ros_2.6.1-3.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/perception-pcl/pcl-ros_2.6.1-3.bbappend
@@ -1,0 +1,5 @@
+
+# QA Issue: File /opt/ros/rolling/share/pcl_ros/cmake/export_pcl_rosExport.cmake in package pcl-ros-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}##g" ${D}${ros_datadir}/pcl_ros/cmake/export_pcl_rosExport.cmake
+}

--- a/meta-ros2-rolling/recipes-bbappends/rosbag2-storage-mcap/mcap-vendor/0001-CMakeLists.txt-fetch-dependencies-with-bitbake-fetch.patch
+++ b/meta-ros2-rolling/recipes-bbappends/rosbag2-storage-mcap/mcap-vendor/0001-CMakeLists.txt-fetch-dependencies-with-bitbake-fetch.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 Index: git/CMakeLists.txt
 ===================================================================
 --- git.orig/CMakeLists.txt


### PR DESCRIPTION
A couple of small changes to allow the ros-base and perception variants on rolling compile.