### PR TITLE
kas: debug-tweaks as IMAGE_FEATURE is removed

### DIFF
--- a/kas/common.yml
+++ b/kas/common.yml
@@ -4,7 +4,7 @@ header:
 local_conf_header:
   common: |
     DISTRO_FEATURES += "usrmerge"
-    IMAGE_FEATURES += "debug-tweaks"
+    IMAGE_FEATURES += "empty-root-password allow-empty-password allow-root-login post-install-logging"
     INHERIT += "report-error"
     INHERIT += "rm_work"
     INHERIT_DISTRO:remove = "create-spdx"


### PR DESCRIPTION
And replaced it by the features that was below it.

see:
  commit 43b8b3fa72d75d8d82a478613a4d9bf4645b5389
  Author: Ross Burton <ross.burton@arm.com>
  Date:   Thu Nov 7 13:47:52 2024 +0000

      classes-recipe/core-image: drop debug-tweaks IMAGE_FEATURE

      Remove the 'debug-tweaks' IMAGE_FEATURE. It sounds friendly and kind to
      developers, but it results primarily in an image which root can login
      remotely without a password.  This is incredibly useful for local
      development and testing purposes, but we really want to be explicit that
      this is what is happening instead of hiding it behind a vague "debug
      tweaks" statement.

      To preserve the eixsting behaviour, debug-tweaks should be replaced with
      these features:

        allow-empty-password empty-root-password allow-root-login post-install-logging

      (From OE-Core rev: 2c229f9542c6ba608912e14c9c3f783c3fa89349)

      Signed-off-by: Ross Burton <ross.burton@arm.com>
      Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>