### PR TITLE
{common}{ros2} (Backport) Add ROS opt prefix to PYTHONPATH Kirkstone

### DIFF
--- a/meta-ros-common/classes/ros_opt_prefix.bbclass
+++ b/meta-ros-common/classes/ros_opt_prefix.bbclass
@@ -30,9 +30,56 @@ ROS_PYTHON_VERSION ?= "3"
 inherit ${@'python3-dir' if d.getVar('ROS_PYTHON_VERSION') == '3' else 'python-dir'}
 
 PKG_CONFIG_PATH .= ":${PKG_CONFIG_DIR}:${STAGING_DIR_HOST}${ros_libdir}/pkgconfig:${STAGING_DATADIR}/pkgconfig"
+
 PYTHON_SITEPACKAGES_DIR = "${ros_libdir}/${PYTHON_DIR}/site-packages"
-export PYTHONPATH:prepend = "${STAGING_DIR_NATIVE}${PYTHON_SITEPACKAGES_DIR}:"
-PYTHONPATH:class-native:prepend = "${PYTHON_SITEPACKAGES_DIR}:"
+
+setup_rosoptprefix_config() {
+        if [ -n "$PYTHON" ]; then export PYTHONPATH=${STAGING_DIR_NATIVE}${ros_libdir}/${PYTHON_DIR}/site-packages:$PYTHONPATH; fi
+}
+
+do_configure:prepend:class-target() {
+        setup_rosoptprefix_config
+}
+
+do_compile:prepend:class-target() {
+        setup_rosoptprefix_config
+}
+
+do_install:prepend:class-target() {
+        setup_rosoptprefix_config
+}
+
+setup_rosoptprefix_native_config() {
+        if [ -n "$PYTHON" ]; then export PYTHONPATH=${ros_libdir}/${PYTHON_DIR}/site-packages:$PYTHONPATH; fi
+}
+
+do_configure:prepend:class-native() {
+        setup_rosoptprefix_native_config
+}
+
+do_compile:prepend:class-native() {
+        setup_rosoptprefix_native_config
+}
+
+do_install:prepend:class-native() {
+        setup_rosoptprefix_native_config
+}
+
+setup_rosoptprefix_nativesdk_config() {
+        if [ -n "$PYTHON" ]; then export PYTHONPATH=${STAGING_DIR_NATIVE}${ros_base_prefix}/lib/${PYTHON_DIR}/site-packages:$PYTHONPATH; fi
+}
+
+do_configure:prepend:class-nativesdk() {
+        setup_rosoptprefix_nativesdk_config
+}
+
+do_compile:prepend:class-nativesdk() {
+        setup_rosoptprefix_nativesdk_config
+}
+
+do_install:prepend:class-nativesdk() {
+        setup_rosoptprefix_nativesdk_config
+}
 
 FILES_SOLIBSDEV += " ${ros_libdir}/lib*${SOLIBSDEV}"
 

--- a/meta-ros2/classes/ros_ament_cmake.bbclass
+++ b/meta-ros2/classes/ros_ament_cmake.bbclass
@@ -26,8 +26,6 @@ export AMENT_PREFIX_PATH="${STAGING_DIR_HOST}${prefix};${STAGING_DIR_NATIVE}${pr
 
 inherit cmake python3native
 
-PYTHONPATH:prepend:class-nativesdk = "${STAGING_DIR_NATIVE}${ros_base_prefix}/lib/python${PYTHON_BASEVERSION}/site-packages:"
-
 FILES:${PN}:prepend = " \
     ${datadir}/ament_index \
 "


### PR DESCRIPTION
{common}{ros2} Add ROS opt prefix to PYTHONPATH

This is a backport based on fixes made by @robwoolley  on master. It allows users on kirkstone to build the ros2 interface packages that typically fail due to incorrect PYTHONPATH
```
In order for Python to find modules in the recipe-sysroot
we must add the path to PYTHONPATH.  However, we must prepend
the path to any previous values of PYTHONPATH.

We cannot refer to the variable in its own definition since
bitbake does not evaluate strings in that way.

Instead we must mimick python3targetconfig.bbclass and
prepend to the recipe tasks to conditionally set PYTHONPATH
in the shell context.
```
