### PR TITLE
generate_recipes.yml: Add --set-upstream to git push

### DIFF
--- a/.github/workflows/generate_recipes.yml
+++ b/.github/workflows/generate_recipes.yml
@@ -115,7 +115,7 @@ jobs:
           if [ "${CURRENT_BRANCH}" = "superflore/${ROS_DISTRO}/${ROS_DISTRO_RELEASE_DATE_ONLY}" ]; then
             echo "Pushing to superflore/$GITHUB_REF_NAME/${ROS_DISTRO}/${ROS_DISTRO_RELEASE_DATE_ONLY}"
             git branch -M superflore/$GITHUB_REF_NAME/${ROS_DISTRO}/${ROS_DISTRO_RELEASE_DATE_ONLY}
-            git push origin superflore/$GITHUB_REF_NAME/${ROS_DISTRO}/${ROS_DISTRO_RELEASE_DATE_ONLY}
+            git push --set-upstream origin superflore/$GITHUB_REF_NAME/${ROS_DISTRO}/${ROS_DISTRO_RELEASE_DATE_ONLY}
             echo "Creating Pull Request"
             gh pr create --title "Superflore Update for $GITHUB_REF_NAME : ${ROS_DISTRO} : ${ROS_DISTRO_RELEASE_DATE_ONLY}" --base $GITHUB_REF_NAME --fill-verbose 
           else


### PR DESCRIPTION
The GitHub CLI command had a regression where it fails when trying to create a pull request:

  aborted: you must first push the current branch to a remote, or use the --head flag

This will be fixed in upstream releases. However, setting --set-upstream on the git push command is reported to work around this issue. (See https://github.com/cli/cli/issues/10188)