### PR TITLE
Fix: bitbake fails to find libc++abi.so when compiling with LLVM/Clang.

### DIFF
--- a/meta-ros-common/recipes-devtools/cpptoml/cpptoml/0002-Fix-build-with-clang.patch
+++ b/meta-ros-common/recipes-devtools/cpptoml/cpptoml/0002-Fix-build-with-clang.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ec25cc..802d1a9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,17 +20,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/deps/meta-cmake)
+ 
+ if(UNIX OR MINGW)
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
+-
+-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+-    if(CMAKE_GENERATOR STREQUAL "Ninja")
+-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
+-    endif()
+-
+-    if(ENABLE_LIBCXX)
+-      find_package(LIBCXX REQUIRED)
+-      set_libcxx_required_flags()
+-    endif()
+-  endif()
+ endif()
+ 
+ set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${CMAKE_CXX11_STANDARD_COMPILE_OPTION}")

--- a/meta-ros-common/recipes-devtools/cpptoml/cpptoml_0.1.1.bb
+++ b/meta-ros-common/recipes-devtools/cpptoml/cpptoml_0.1.1.bb
@@ -2,7 +2,8 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8739ce451f437fa9493b37a405fb16f1"
 
 SRC_URI = "gitsm://github.com/skystrife/cpptoml.git;protocol=https;branch=master \
-           file://0001-Fix-build-with-gcc-11.patch"
+           file://0001-Fix-build-with-gcc-11.patch \
+           file://0002-Fix-build-with-clang.patch"
 
 PV = "0.1.1+git"
 SRCREV = "fededad7169e538ca47e11a9ee9251bc361a9a65"


### PR DESCRIPTION
Without the patch the compilation of libiceoryx_posh_config.so is failing with

```bash
NOTE: VERBOSE=1 cmake --build /dockerVolume/build-lmp-base/tmp-lmp_base/work/cortexa53-lmp-linux/iceoryx-posh/2.0.5-6-r0/build --target all -- ninja: error: '/dockerVolume/build-lmp-base/tmp-lmp_base/work/cortexa53-lmp-linux/cpptoml/0.1.1+git-r0/recipe-sysroot/usr/lib/libc++abi.so', needed by 'libiceoryx_posh_config.so', missing and no known rule to make it .
```