### PR TITLE
{styhead} Make sdformat-urdf compile for ros2 control

### DIFF
--- a/meta-ros-common/recipes-devtools/gazebo/gz-cmake3/Fix-pkgconfig-install-dir.patch
+++ b/meta-ros-common/recipes-devtools/gazebo/gz-cmake3/Fix-pkgconfig-install-dir.patch
@@ -10,6 +10,8 @@ CMAKE_INSTALL_FULL_LIBDIR/pkgconfig which is an absolute path.
 We should use CMAKE_INSTALL_LIBDIR instead so that it is a
 relative path and CMAKE_INSTALL_PREFIX can be used.
 
+Upsteam-Status: Inappropriate [oe specific]
+
 Signed-off by: Rob Woolley <rob.woolley@windriver.com>
 
 diff --git a/cmake/GzPackaging.cmake b/cmake/GzPackaging.cmake

--- a/meta-ros-common/recipes-devtools/gazebo/gz-cmake4/Fix-pkgconfig-install-dir.patch
+++ b/meta-ros-common/recipes-devtools/gazebo/gz-cmake4/Fix-pkgconfig-install-dir.patch
@@ -1,0 +1,29 @@
+
+Fix pkgconfig installation directory
+
+Packages which use gz-cmake3 will fail to install when
+building cross-platform and CMAKE_INSTALL_PREFIX is set.
+
+This happens because pkgconfig_install_dir uses
+CMAKE_INSTALL_FULL_LIBDIR/pkgconfig which is an absolute path.
+
+We should use CMAKE_INSTALL_LIBDIR instead so that it is a
+relative path and CMAKE_INSTALL_PREFIX can be used.
+
+Upstream-Status: Inappropriate [oe specific]
+
+Signed-off by: Rob Woolley <rob.woolley@windriver.com>
+
+diff --git a/cmake/GzPackaging.cmake b/cmake/GzPackaging.cmake
+index f3a8ae0..4a2b633 100644
+--- a/cmake/GzPackaging.cmake
++++ b/cmake/GzPackaging.cmake
+@@ -227,7 +227,7 @@ function(_gz_create_pkgconfig)
+
+   install(
+     FILES ${pkgconfig_output}
+-    DESTINATION ${pkgconfig_install_dir}
++    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+     COMPONENT pkgconfig)
+
+ endfunction()

--- a/meta-ros-common/recipes-devtools/gazebo/gz-cmake4_4.1.0.bb
+++ b/meta-ros-common/recipes-devtools/gazebo/gz-cmake4_4.1.0.bb
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Wind River Systems, Inc.
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2a461be67a1edf991251f85f3aadd1d0"
+
+SRC_URI = "git://github.com/gazebosim/gz-cmake.git;protocol=https;branch=gz-cmake4 \
+           file://Fix-pkgconfig-install-dir.patch"
+
+SRCREV = "eb1c510e6278935eb742ed92c6a6d1388439f8bd"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+FILES:${PN} += "${datadir}/gz/gz-cmake4/*"
+
+FILES:${PN}-dev += " \
+    pkgconfig/gz-cmake4.pc \
+    ${includedir} \
+    ${datadir}/cmake/gz-cmake4/cmake4/ \
+    ${datadir}/gz/gz-cmake4/ \
+"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros-common/recipes-devtools/gazebo/gz-math8_8.1.0.bb
+++ b/meta-ros-common/recipes-devtools/gazebo/gz-math8_8.1.0.bb
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Wind River Systems, Inc.
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2a461be67a1edf991251f85f3aadd1d0"
+
+SRC_URI = "git://github.com/gazebosim/gz-math.git;protocol=https;branch=gz-math8"
+
+SRCREV = "2179284cb6fe77f42001c4797e060c034d8e92dc"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = " \
+    gz-cmake4 \
+    gz-cmake4-native \
+    gz-utils3 \
+    libeigen \
+    python3 \
+    python3-pybind11 \
+    ruby \
+    swig-native \
+"
+
+inherit cmake python3targetconfig
+
+FILES:${PN} += "${libdir}/python/"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros-common/recipes-devtools/gazebo/gz-tools2_2.0.1.bb
+++ b/meta-ros-common/recipes-devtools/gazebo/gz-tools2_2.0.1.bb
@@ -20,7 +20,7 @@ DEPENDS = " \
     libyaml \
     libzip \
     backward-cpp \
-    gz-cmake3 \
+    gz-cmake4 \
 "
 
 

--- a/meta-ros-common/recipes-devtools/gazebo/gz-utils3_3.1.0.bb
+++ b/meta-ros-common/recipes-devtools/gazebo/gz-utils3_3.1.0.bb
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 Wind River Systems, Inc.
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=388d6baacb3a7c79a82bd82a679c65f3 \
+                    file://cli/LICENSE;md5=b73927b18d5c6cd8d2ed28a6ad539733"
+
+SRC_URI = "git://github.com/gazebosim/gz-utils.git;protocol=https;branch=gz-utils3"
+
+SRCREV = "5e1e78be9e4df46c4cfc97165a6447753d179cff"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+DEPENDS = "gz-cmake4"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros-common/recipes-devtools/gazebo/sdformat_15.1.1.bb
+++ b/meta-ros-common/recipes-devtools/gazebo/sdformat_15.1.1.bb
@@ -1,0 +1,34 @@
+# Copyright (c) 2024 Wind River Systems, Inc.
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2a461be67a1edf991251f85f3aadd1d0"
+
+SRC_URI = "git://github.com/gazebosim/sdformat.git;protocol=https;branch=sdf15"
+
+SRCREV = "cc524e7ebea952652aea3b03a95f13dc6416c563"
+
+S = "${WORKDIR}/git"
+
+inherit cmake pkgconfig
+
+DEPENDS = " \
+    gz-cmake-vendor \
+    gz-math-vendor \
+    gz-tools-vendor \
+    gz-utils-vendor \
+    libtinyxml2 \
+    python3-pybind11 \
+    python3-psutil-native \
+    ruby-native \
+    urdfdom \
+"
+
+FILES:${PN} += " \
+    ${libdir}/ruby/gz \
+    ${datadir}/gz \
+    ${datadir}/sdformat15/* \
+"
+
+do_install:append() {
+    rm ${D}/usr/lib/python/sdformat15.cpython-312-x86_64-linux-gnu.so
+    rm -r ${D}/usr/lib/python
+}

--- a/meta-ros2-rolling/recipes-bbappends/gz-cmake-vendor/gz-cmake-vendor_0.2.1-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/gz-cmake-vendor/gz-cmake-vendor_0.2.1-1.bbappend
@@ -1,11 +1,11 @@
 # Copyright (c) 2024 Wind River Systems, Inc.
 
-export GZ_RELAX_VERSION_MATCH="1"
+#export GZ_RELAX_VERSION_MATCH="1"
 
-ROS_BUILD_DEPENDS += "gz-cmake3"
+ROS_BUILD_DEPENDS += "gz-cmake4"
 
 # See CMakeLists.txt for details on why /usr/opt/gz_cmake_vendor/ is used
-FILES:${PN} += "${datadir}/gz/gz-cmake3/* \
+FILES:${PN} += "${datadir}/gz/gz-cmake4/* \
                 ${prefix}/opt/gz_cmake_vendor/extra_cmake/lib/cmake/gz-cmake/*"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros2-rolling/recipes-bbappends/gz-math-vendor/gz-math-vendor_0.2.2-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/gz-math-vendor/gz-math-vendor_0.2.2-1.bbappend
@@ -3,7 +3,7 @@
 # ERROR: QA Issue: non -dev/-dbg/nativesdk- package gz-math-vendor contains symlink .so '/opt/ros/rolling/lib/libgz-math7.so' [dev-so]
 inherit ros_insane_dev_so
 
-ROS_BUILD_DEPENDS += "gz-math7"
+ROS_BUILD_DEPENDS += "gz-math8"
 
 export GZ_RELAX_VERSION_MATCH="1"
 

--- a/meta-ros2-rolling/recipes-bbappends/gz-utils-vendor/gz-utils-vendor_0.2.1-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/gz-utils-vendor/gz-utils-vendor_0.2.1-1.bbappend
@@ -3,6 +3,6 @@
 # ERROR: QA Issue: non -dev/-dbg/nativesdk- package gz-utils-vendor contains symlink .so '/opt/ros/rolling/lib/libgz-utils2.so' [dev-so]
 inherit ros_insane_dev_so
 
-ROS_BUILD_DEPENDS += "gz-utils2"
+ROS_BUILD_DEPENDS += "gz-utils3"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
ROS2 Controls now depends on sdformat-urdf. For this to compile on rolling, update to Gazebo vendor packages is required, update:

* gz-cmake3 moves to gz-cmake4
* gz-utils2 move to gz-utils3
* gz-math7 moves to gz-math8
* sdformat moves to version 15