### PR TITLE
doc: bmaptool can handle compressed wic files

### DIFF
--- a/kas/README.md
+++ b/kas/README.md
@@ -43,7 +43,7 @@ build/tmp-glibc/deploy/images/raspberrypi4-64/ros-image-core-humble-raspberrypi4
 If using [Balena Etcher](https://etcher.balena.io/), you may provide it with
 this file directly.
 
-If using dd or bmaptool, you must first decompress the bzip2 file.
+If using dd, you must first decompress the bzip2 file.
 
 If using bmaptool, you may follow the instructions here:
 https://docs.yoctoproject.org/dev/dev-manual/bmaptool.html


### PR DESCRIPTION
It is not longer needed to decompress the wic file to be used with bmaptool.

From the man page fo bmaptool:

  IMAGE may be compressed, in which case bmaptool decompresses it on-the-fly.  The compression type is detected by the file extension and the following extensions are supported:

      1. ".gz", ".gzip", ".tar.gz" and ".tgz" for files and tar archives compressed with "gzip" program
      2. ".bz2", "tar.bz2", ".tbz2", ".tbz", and ".tb2" for files and tar archives compressed with "bzip2" program 3. ".xz", ".tar.xz", ".txz" for files and tar archives compressed with "xz" program 4. ".lzo", "tar.lzo", ".tzo" for files and tar archives compressed with "lzo" program 5. ".lz4", "tar.lz4", ".tlz4" for files and tar archives compressed with "lz4" program 6. ".zst", "tar.zst", ".tzst" for files and tar archives compressed with "zstd" program