### PR TITLE
Fix tl-expected build issue

### DIFF
--- a/meta-ros2-jazzy/recipes-bbappends/cpp-polyfills/tl-expected_%.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/cpp-polyfills/tl-expected_%.bbappend
@@ -1,0 +1,3 @@
+# ERROR: tl-expected-1.0.2-5-r0 do_create_spdx: Cannot find any text for license Creative-Commons-Zero-v1.0-Universal
+# Convert Creative-Commons-Zero-v1.0-Universal to SPDX identifier CC0-1.0
+LICENSE = "CC0-1.0"


### PR DESCRIPTION
Log:
```
ERROR: tl-expected-1.0.2-5-r0 do_create_spdx: Cannot find any text for license Creative-Commons-Zero-v1.0-Universal
```
This change should also be applicable to other distros as well, i think.