### PR TITLE
kas: adding oeros-styhead-rolling-raspberrypi5

### DIFF
--- a/kas/oeros-styhead-rolling-raspberrypi5.yml
+++ b/kas/oeros-styhead-rolling-raspberrypi5.yml
@@ -1,0 +1,11 @@
+header:
+  version: 14
+  includes:
+    - kas/yocto/styhead.yml
+    - kas/ros2/rolling.yml
+    - kas/machine/raspberrypi5.yml
+    - kas/common.yml
+
+repos:
+  raspberrypi:
+    branch: "master"


### PR DESCRIPTION
Being:
  - latest release of Yocto (Styhead)
  - rolling release of ROS
  - machine is RaspberryPi 5

meta-raspberrypi doesn not yet have a branch for Styhead