### PR TITLE
[kirkstone][scarthgap][walnascar][master] {common} python3-sphinx: remove recipe, available in openembedded-core.

### DIFF
--- a/meta-ros-common/recipes-devtools/python/python3-sphinx_1.6.7.bb
+++ b/meta-ros-common/recipes-devtools/python/python3-sphinx_1.6.7.bb
@@ -1,5 +1,0 @@
-# Copyright (c) 2019 LG Electronics, Inc.
-
-require python-sphinx.inc
-
-inherit setuptools3

--- a/meta-ros2/recipes-devtools/python/python3-rosdoc2_0.2.1.bb
+++ b/meta-ros2/recipes-devtools/python/python3-rosdoc2_0.2.1.bb
@@ -1,0 +1,32 @@
+SUMMARY = "Command-line tool for generating documentation for ROS 2 packages."
+DESCRIPTION = "\
+    This tool can be viewed from two perspectives: \
+    first from the perspective of a user wanting to building documentation for any given ROS 2 package in order to view it, \
+    and second from the perspective of package maintainers who need to write their documentation \
+    and configure how this tool works on their package. \
+"
+HOMEPAGE = "https://github.com/ros-infrastructure/rosdoc2"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://PKG-INFO;beginline=10;endline=10;md5=d36ab912b8b544b7412f2d84c52072f1"
+
+SRC_URI[sha256sum] = "fbb2ba4d0d867590955963363bf24b969c6ed18c24d730845b38884736b8ccf7"
+
+inherit pypi python_setuptools_build_meta
+
+RDEPENDS:${PN} = "\
+    osrf-pycommon \
+    python3-breathe \
+    python3-catkin-pkg \
+    python3-exhale \
+    python3-jinja2 \
+    python3-myst-parser \
+    python3-pyyaml \
+    python3-rosdistro \
+    python3-setuptools \
+    python3-sphinx \
+    python3-sphinx-rtd-theme \
+    "
+
+PYPI_PACKAGE = "rosdoc2"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
@robwoolley Could you verify if this is correct with all branches, releases and tooling?

The python3-sphinx recipe in meta-ros is outdated. A well-maintained  version is available in openembedded-core.  

Only one recipe in meta-ros (cartographer & cartographer-ros) depends on it,  
and even there, it is only used for documentation generation.  
It is hardly a necessary RDEPENDS for Yocto.  


Br