### PR TITLE
[scarthgap] {jazzy}: fix librealsense2 recipe to support cmake-based fetching of nlohmann/json

### DIFF
--- a/meta-ros2-jazzy/recipes-bbappends/librealsense2/librealsense2_2.55.1-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/librealsense2/librealsense2_2.55.1-1.bbappend
@@ -1,0 +1,23 @@
+do_configure[network] = "1"
+
+DEPENDS += " \
+    curl \
+"
+
+ROS_BUILDTOOL_DEPENDS += " \
+    pkgconfig-native \
+"
+
+EXTRA_OECMAKE += " \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_UNIT_TESTS=OFF \
+    -DBUILD_PYTHON_BINDINGS=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_TOOLS=OFF \
+    -DCHECK_FOR_UPDATES=OFF \
+    -DBUILD_WITH_DDS=OFF \
+"
+
+# ERROR: QA Issue: non -dev/-dbg/nativesdk- package librealsense2 contains symlink .so '/usr/lib/librealsense2.so' [dev-so]
+FILES:${PN}-dev += "${ros_libdir}/librealsense2.so"


### PR DESCRIPTION
The cmake file in the library librealsense2 2.55.1 tries to download `nlohmann/json`. This cannot be disabled by some flags. Patching the cmake file seems to be a little bit difficult and I could not find a better way than allowing the recipe network access.

I am not sure, if the branch `scarthgap-next` is the correct branch. I only tested it with Scarthcap and Jazzy.

Compiling the library without the patch results in following error:
```
bitbake librealsense2
```
```
| NOTE: Installed into sysroot: []
| NOTE: Skipping as already exists in sysroot: ['glfw', 'openssl', 'base-files', 'base-passwd', 'expat', 'gettext-minimal-native', 'glib-2.0', 'glibc', 'libxcrypt', 'libxml2', 'ncurses', 'systemd', 'util-linux-libuuid', 'util-linux', 'zlib', 'binutils-cross-aarch64', 'cmake-native', 'gcc-cross-aarch64', 'gcc-runtime', 'libgcc', 'git', 'libedit', 'libtool-native', 'm4-native', 'opkg-utils', 'pkgconfig', 'python3', 'quilt-native', 'bzip2', 'libidn2', 'libnsl2', 'libtirpc', 'shadow-sysroot', 'shadow', 'texinfo-dummy-native', 'xz', 'zstd', 'libdrm', 'libglu', 'mesa', 'xrandr', 'libpciaccess', 'libpthread-stubs', 'libx11', 'libxau', 'libxcb', 'libxcursor', 'libxdamage', 'libxdmcp', 'libxext', 'libxfixes', 'libxi', 'libxinerama', 'libxkbcommon', 'libxrandr', 'libxrender', 'libxshmfence', 'libxxf86vm', 'xkeyboard-config', 'xtrans', 'xcb-proto', 'xorgproto', 'util-macros', 'kmod', 'linux-libc-headers', 'libpng', 'bash-completion', 'curl', 'gdbm', 'libcap-ng', 'libcap', 'libffi', 'libpcre2', 'libunistring', 'libusb1', 'sqlite3', 'openssl-native', 'ncurses-native', 'zlib-native', 'flex-native', 'gnu-config-native', 'make-native', 'ninja-native', 'patch-native', 'perl-native', 'pseudo-native', 'bzip2-native', 'shadow-native', 'xz-native', 'zstd-native', 'attr-native', 'gdbm-native', 'gmp-native', 'libbsd-native', 'libmd-native', 'libmpc-native', 'mpfr-native', 're2c-native', 'sqlite3-native']
| DEBUG: Python function extend_recipe_sysroot finished
| DEBUG: Executing shell function do_configure
| -- The CXX compiler identification is GNU 13.3.0
| -- The C compiler identification is GNU 13.3.0
| -- Detecting CXX compiler ABI info
| -- Detecting CXX compiler ABI info - done
| -- Check for working CXX compiler: /btrfs/home/current/fischejo/projects/yocto/build/tmp-glibc/work/cortexa72-oe-linux/librealsense2/2.55.1-1/recipe-sysroot-native/usr/bin/aarch64-oe-linux/aarch64-oe-linux-g++ - skipped
| -- Detecting CXX compile features
| -- Detecting CXX compile features - done
| -- Detecting C compiler ABI info
| -- Detecting C compiler ABI info - done
| -- Check for working C compiler: /btrfs/home/current/fischejo/projects/yocto/build/tmp-glibc/work/cortexa72-oe-linux/librealsense2/2.55.1-1/recipe-sysroot-native/usr/bin/aarch64-oe-linux/aarch64-oe-linux-gcc - skipped
| -- Detecting C compile features
| -- Detecting C compile features - done
| -- Checking internet connection...
| -- Failed to identify Internet connection
| CMake Warning at CMakeLists.txt:22 (message):
|   No internet connection, disabling IMPORT_DEPTH_CAM_FW
| 
| 
| -- Info: REALSENSE_VERSION_STRING=2.55.1
| -- Setting Unix configurations
| -- No output directory set; using /btrfs/home/current/fischejo/projects/yocto/build/tmp-glibc/work/cortexa72-oe-linux/librealsense2/2.55.1-1/build/Release/
| -- Building libcurl enabled
| -- Found OpenSSL: /btrfs/home/current/fischejo/projects/yocto/build/tmp-glibc/work/cortexa72-oe-linux/librealsense2/2.55.1-1/recipe-sysroot/usr/lib/libcrypto.so (found version "3.2.3")
| -- Performing Test SUPPORTS_CXX14
| -- Performing Test SUPPORTS_CXX14 - Success
| -- using RS2_USE_V4L2_BACKEND
| -- Found usb: /btrfs/home/current/fischejo/projects/yocto/build/tmp-glibc/work/cortexa72-oe-linux/librealsense2/2.55.1-1/recipe-sysroot/usr/lib/libusb-1.0.so
| -- Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
| -- Found Udev: /btrfs/home/current/fischejo/projects/yocto/build/tmp-glibc/work/cortexa72-oe-linux/librealsense2/2.55.1-1/recipe-sysroot/usr/include
| -- Fetching nlohmann/json...
| CMake Error at CMake/external_json.cmake:34 (message):
|   Failed to download nlohmann/json
| Call Stack (most recent call first):
|   CMake/external_json.cmake:50 (get_nlohmann_json)
|   third-party/CMakeLists.txt:3 (include)
|   CMakeLists.txt:58 (include)
| 
| 
| -- Configuring incomplete, errors occurred!
```