### PR TITLE
[scarthgap] {jazzy}: fix diagnostic-update missing dependency on ament-cmake-ros-native

### DIFF
--- a/meta-ros2-jazzy/recipes-bbappends/diagnostic-updater/diagnostic-updater_4.2.1-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/diagnostic-updater/diagnostic-updater_4.2.1-1.bbappend
@@ -1,0 +1,1 @@
+ROS_BUILDTOOL_DEPENDS += "ament-cmake-ros-native"


### PR DESCRIPTION
Recipe diagnostic-updater missing depends on `ament_cmake_ros`.
```
bitbake diagnostic-updater
```
```
| DEBUG: Python function extend_recipe_sysroot finished
| DEBUG: Executing shell function do_configure
| -- The C compiler identification is GNU 13.3.0
| -- The CXX compiler identification is GNU 13.3.0
| -- Detecting C compiler ABI info
| -- Detecting C compiler ABI info - done
| -- Check for working C compiler: /btrfs/home/current/fischejo/projects/yocto/build/tmp-glibc/work/cortexa72-oe-linux/diagnostic-updater/4.2.1-1/recipe-sysroot-native/usr/bin/aarch64-oe-linux/aarch64-oe-linux-gcc - skipped
| -- Detecting C compile features
| -- Detecting C compile features - done
| -- Detecting CXX compiler ABI info
| -- Detecting CXX compiler ABI info - done
| -- Check for working CXX compiler: /btrfs/home/current/fischejo/projects/yocto/build/tmp-glibc/work/cortexa72-oe-linux/diagnostic-updater/4.2.1-1/recipe-sysroot-native/usr/bin/aarch64-oe-linux/aarch64-oe-linux-g++ - skipped
| -- Detecting CXX compile features
| -- Detecting CXX compile features - done
| -- Found ament_cmake: 2.5.3 (/btrfs/home/current/fischejo/projects/yocto/build/tmp-glibc/work/cortexa72-oe-linux/diagnostic-updater/4.2.1-1/recipe-sysroot-native/opt/ros/jazzy/share/ament_cmake/cmake)
| -- Found Python3: /btrfs/home/current/fischejo/projects/yocto/build/tmp-glibc/work/cortexa72-oe-linux/diagnostic-updater/4.2.1-1/recipe-sysroot-native/usr/bin/python3-native/python3 (found version "3.12.8") found components: Interpreter
| -- Configuring incomplete, errors occurred!
| CMake Error at CMakeLists.txt:14 (find_package):
|   By not providing "Findament_cmake_ros.cmake" in CMAKE_MODULE_PATH this
|   project has asked CMake to find a package configuration file provided by
|   "ament_cmake_ros", but CMake did not find one.
| 
|   Could not find a package configuration file provided by "ament_cmake_ros"
|   with any of the following names:
| 
|     ament_cmake_rosConfig.cmake
|     ament_cmake_ros-config.cmake
| 
|   Add the installation prefix of "ament_cmake_ros" to CMAKE_PREFIX_PATH or
|   set "ament_cmake_ros_DIR" to a directory containing one of the above files.
|   If "ament_cmake_ros" provides a separate development package or SDK, be
|   sure it has been installed.
| 
| 
```