### PR TITLE
[scarthgap] {humble} ros2-controllers: resolve miscellaneous build failures and QA issues

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/ackermann-steering-controller_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/ackermann-steering-controller_2.49.1-1.bbappend
@@ -1,3 +1,9 @@
 ROS_BUILDTOOL_DEPENDS += " \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/ackermann_steering_controller/cmake/export_ackermann_steering_controllerExport.cmake in package ackermann-steering-controller-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/bicycle-steering-controller_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/bicycle-steering-controller_2.49.1-1.bbappend
@@ -1,3 +1,9 @@
 ROS_BUILDTOOL_DEPENDS += " \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/bicycle_steering_controller/cmake/export_bicycle_steering_controllerExport.cmake in package bicycle-steering-controller-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/diff-drive-controller_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/diff-drive-controller_2.49.1-1.bbappend
@@ -4,3 +4,9 @@ ROS_BUILDTOOL_DEPENDS += " \
     rosidl-default-generators-native \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/diff_drive_controller/cmake/export_diff_drive_controllerExport.cmake in package diff-drive-controller-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/force-torque-sensor-broadcaster_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/force-torque-sensor-broadcaster_2.49.1-1.bbappend
@@ -4,3 +4,9 @@ ROS_BUILDTOOL_DEPENDS += " \
     generate-parameter-library-py-native \
     python3-pyyaml-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/force_torque_sensor_broadcaster/cmake/export_force_torque_sensor_broadcasterExport.cmake in package force-torque-sensor-broadcaster-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/forward-command-controller_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/forward-command-controller_2.49.1-1.bbappend
@@ -4,3 +4,9 @@ ROS_BUILDTOOL_DEPENDS += " \
     rosidl-default-generators-native \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/forward_command_controller/cmake/export_forward_command_controllerExport.cmake in package forward-command-controller-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/gpio-controllers/0001-remove-missing-braces-error-compile-option.patch
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/gpio-controllers/0001-remove-missing-braces-error-compile-option.patch
@@ -1,0 +1,23 @@
+From 466c37a950af6601a6b125e11703d8ee39fca303 Mon Sep 17 00:00:00 2001
+From: Amelia Grace <agrace@bastiansolutions.com>
+Date: Wed, 30 Apr 2025 14:05:54 -0600
+Subject: [PATCH] remove missing braces error compile option
+
+Signed-off-by: Amelia Grace <agrace@bastiansolutions.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5eedec32e6..c730b0a82d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,7 +8,7 @@ endif()
+ 
+ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+   add_compile_options(-Wall -Wextra -Wpedantic -Werror=conversion -Werror=unused-but-set-variable
+-  -Werror=return-type -Werror=format -Werror=missing-braces)
++  -Werror=return-type -Werror=format)
+ endif()
+ 
+ # find dependencies

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/gpio-controllers_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/gpio-controllers_2.49.1-1.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-remove-missing-braces-error-compile-option.patch"
+
+ROS_BUILDTOOL_DEPENDS += " \
+    generate-parameter-library-py-native \
+"
+
+CXXFLAGS += "-Wno-deprecated-declarations"

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/gripper-controllers_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/gripper-controllers_2.49.1-1.bbappend
@@ -3,3 +3,9 @@
 ROS_BUILDTOOL_DEPENDS += " \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/gripper_controllers/cmake/export_gripper_action_controllerExport.cmake in package gripper-controllers-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_gripper_action_controllerExport.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_gripper_action_controllerExport.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/imu-sensor-broadcaster_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/imu-sensor-broadcaster_2.49.1-1.bbappend
@@ -4,3 +4,9 @@ ROS_BUILDTOOL_DEPENDS += " \
     rosidl-default-generators-native \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/imu_sensor_broadcaster/cmake/export_imu_sensor_broadcasterExport.cmake in package imu-sensor-broadcaster-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/joint-state-broadcaster_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/joint-state-broadcaster_2.49.1-1.bbappend
@@ -3,3 +3,9 @@
 ROS_BUILDTOOL_DEPENDS += " \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/joint_state_broadcaster/cmake/export_joint_state_broadcasterExport.cmake in package joint-state-broadcaster-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/joint-trajectory-controller_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/joint-trajectory-controller_2.49.1-1.bbappend
@@ -3,3 +3,9 @@
 ROS_BUILDTOOL_DEPENDS += " \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/joint_trajectory_controller/cmake/export_joint_trajectory_controllerExport.cmake in package joint-trajectory-controller-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/mecanum-drive-controller_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/mecanum-drive-controller_2.49.1-1.bbappend
@@ -1,8 +1,16 @@
+ROS_BUILD_DEPENDS += " \
+    backward-ros \
+"
+
+ROS_EXEC_DEPENDS += " \
+    backward-ros \
+"
+
 ROS_BUILDTOOL_DEPENDS += " \
     generate-parameter-library-py-native \
 "
 
-# QA Issue: File /opt/ros/humble/share/admittance_controller/cmake/export_admittance_controllerExport.cmake in package admittance-controller-dev contains reference to TMPDIR [buildpaths]
+# QA Issue: File /opt/ros/humble/share/mecanum_drive_controller/cmake/export_mecanum_drive_controllerExport.cmake in package mecanum-drive-controller-dev contains reference to TMPDIR [buildpaths]
 do_install:append() {
     sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
     sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/pid-controller_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/pid-controller_2.49.1-1.bbappend
@@ -2,7 +2,7 @@ ROS_BUILDTOOL_DEPENDS += " \
     generate-parameter-library-py-native \
 "
 
-# QA Issue: File /opt/ros/humble/share/admittance_controller/cmake/export_admittance_controllerExport.cmake in package admittance-controller-dev contains reference to TMPDIR [buildpaths]
+# QA Issue: File /opt/ros/humble/share/pid_controller/cmake/export_pid_controllerExport.cmake in package pid-controller-dev contains reference to TMPDIR [buildpaths]
 do_install:append() {
     sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
     sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/pose-broadcaster/0001-remove-shadow-error-compile-option.patch
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/pose-broadcaster/0001-remove-shadow-error-compile-option.patch
@@ -1,0 +1,23 @@
+From b33e51a489db69250158401cd5e344ef619d80c4 Mon Sep 17 00:00:00 2001
+From: Amelia Grace <agrace@bastiansolutions.com>
+Date: Wed, 30 Apr 2025 14:51:32 -0600
+Subject: [PATCH] remove shadow error compile option
+
+Signed-off-by: Amelia Grace <agrace@bastiansolutions.com>
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 46028cf258..b41835f449 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -6,7 +6,7 @@ project(pose_broadcaster
+ 
+ if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
+   add_compile_options(-Wall -Wextra -Wpedantic -Werror=conversion -Werror=unused-but-set-variable
+-                      -Werror=return-type -Werror=shadow -Werror=format)
++                      -Werror=return-type -Werror=format)
+ endif()
+ 
+ set(THIS_PACKAGE_INCLUDE_DEPENDS

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/pose-broadcaster_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/pose-broadcaster_2.49.1-1.bbappend
@@ -1,0 +1,15 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-remove-shadow-error-compile-option.patch"
+
+ROS_BUILDTOOL_DEPENDS += " \
+    generate-parameter-library-py-native \
+"
+
+CXXFLAGS += "-Wno-deprecated-declarations"
+
+# QA Issue: File /opt/ros/humble/share/pose_broadcaster/cmake/export_pose_broadcasterExport.cmake in package pose-broadcaster-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/range-sensor-broadcaster_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/range-sensor-broadcaster_2.49.1-1.bbappend
@@ -1,3 +1,9 @@
 ROS_BUILDTOOL_DEPENDS += " \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/range_sensor_broadcaster/cmake/export_range_sensor_broadcasterExport.cmake in package range-sensor-broadcaster-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/steering-controllers-library_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/steering-controllers-library_2.49.1-1.bbappend
@@ -4,3 +4,9 @@ ROS_BUILDTOOL_DEPENDS += " \
     rosidl-default-generators-native \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/steering_controllers_library/cmake/export_steering_controllers_libraryExport.cmake in package steering-controllers-library-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/tricycle-controller_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/tricycle-controller_2.49.1-1.bbappend
@@ -1,0 +1,5 @@
+# QA Issue: File /opt/ros/humble/share/tricycle_controller/cmake/export_tricycle_controllerExport.cmake in package tricycle-controller-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}

--- a/meta-ros2-humble/recipes-bbappends/ros2-controllers/tricycle-steering-controller_2.49.1-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/ros2-controllers/tricycle-steering-controller_2.49.1-1.bbappend
@@ -1,3 +1,9 @@
 ROS_BUILDTOOL_DEPENDS += " \
     generate-parameter-library-py-native \
 "
+
+# QA Issue: File /opt/ros/humble/share/tricycle_steering_controller/cmake/export_tricycle_steering_controllerExport.cmake in package tricycle-steering-controller-dev contains reference to TMPDIR [buildpaths]
+do_install:append() {
+    sed -i -e "s#${RECIPE_SYSROOT}[^;]*;##g" ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+    sed -i -e 's#${RECIPE_SYSROOT}[^"]*##g' ${D}${ros_datadir}/${ROS_BPN}/cmake/export_${ROS_BPN}Export.cmake
+}


### PR DESCRIPTION
After the latest bump to version 2.44.0-1, several of the `ros2-controllers` recipes have build failures (missing dependencies) or QA issues (TMPDIR contamination). This PR resolves all such errors.

To test, build `ros2-controllers` while including the `meta-ros2-humble` layer in your `bblayers.conf` and confirm all controllers build successfully without QA issues.