### PR TITLE
kas: removed the 'ERROR_QA:remove = "license-exists"'

### DIFF
--- a/kas/yocto/master.yml
+++ b/kas/yocto/master.yml
@@ -32,7 +32,3 @@ repos:
       meta-python:
       meta-webserver:
       meta-xfce:
-
-local_conf_header:
-  distro: |
-    ERROR_QA:remove = "license-exists"


### PR DESCRIPTION
On master/kilted with ros-image-core, no warnings or errors appeared.

See: https://github.com/ros/meta-ros/issues/1413