### PR TITLE
[scarthgap] launch-testing-ament-cmake: Set LICENSE

### DIFF
--- a/meta-ros2-humble/recipes-bbappends/launch/launch-testing-ament-cmake_1.0.10-1.bbappend
+++ b/meta-ros2-humble/recipes-bbappends/launch/launch-testing-ament-cmake_1.0.10-1.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"

--- a/meta-ros2-jazzy/recipes-bbappends/launch/launch-testing-ament-cmake_3.4.5-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/launch/launch-testing-ament-cmake_3.4.5-1.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"

--- a/meta-ros2-kilted/recipes-bbappends/launch/launch-testing-ament-cmake_3.8.1-2.bbappend
+++ b/meta-ros2-kilted/recipes-bbappends/launch/launch-testing-ament-cmake_3.8.1-2.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"

--- a/meta-ros2-rolling/recipes-bbappends/launch/launch-testing-ament-cmake_3.9.1-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/launch/launch-testing-ament-cmake_3.9.1-1.bbappend
@@ -1,0 +1,1 @@
+LICENSE = "Apache-2.0 & BSD-3-Clause"


### PR DESCRIPTION

* This fixes an issue while compiling scarthgap with AGL
* Backport the original patchset

Resolves: ERROR: launch-testing-ament-cmake-1.0.8-1-r0 do_create_spdx: Cannot find any text for license BSD