### PR TITLE
kas: renamed 'excluded' -> 'disabled'

### DIFF
--- a/kas/yocto/kirkstone.yml
+++ b/kas/yocto/kirkstone.yml
@@ -20,7 +20,7 @@ repos:
     commit: "046871d9fd76efdca7b72718b328d8f545523f7e"
     path: "layers/bitbake"
     layers:
-      bitbake: "excluded"
+      bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"

--- a/kas/yocto/master.yml
+++ b/kas/yocto/master.yml
@@ -16,7 +16,7 @@ repos:
     url: "https://github.com/openembedded/bitbake.git"
     path: "layers/bitbake"
     layers:
-      bitbake: "excluded"
+      bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"

--- a/kas/yocto/mickledore.yml
+++ b/kas/yocto/mickledore.yml
@@ -20,7 +20,7 @@ repos:
     commit: "c7e094ec3beccef0bbbf67c100147c449d9c6836"
     path: "layers/bitbake"
     layers:
-      bitbake: "excluded"
+      bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"

--- a/kas/yocto/scarthgap.yml
+++ b/kas/yocto/scarthgap.yml
@@ -20,7 +20,7 @@ repos:
     commit: "696c2c1ef095f8b11c7d2eff36fae50f58c62e5e"
     path: "layers/bitbake"
     layers:
-      bitbake: "excluded"
+      bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"

--- a/kas/yocto/styhead.yml
+++ b/kas/yocto/styhead.yml
@@ -20,7 +20,7 @@ repos:
     commit: "82b9f42126983579da03bdbb4e3ebf07346118a7"
     path: "layers/bitbake"
     layers:
-      bitbake: "excluded"
+      bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"

--- a/kas/yocto/walnascar.yml
+++ b/kas/yocto/walnascar.yml
@@ -20,7 +20,7 @@ repos:
     commit: "5b4e20377eea8d428edf1aeb2187c18f82ca6757"
     path: "layers/bitbake"
     layers:
-      bitbake: "excluded"
+      bitbake: "disabled"
 
   meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"


### PR DESCRIPTION
Kas was giving a warning that 'excluded' should be replaced by 'disabled'.

see: https://github.com/siemens/kas/commit/3da781d781b44d6cb5271559297c61f6a6e7b261