### PR TITLE
kas: do check at master for the QA error 'license-exists'

### DIFF
--- a/kas/yocto/master.yml
+++ b/kas/yocto/master.yml
@@ -32,7 +32,3 @@ repos:
       meta-python:
       meta-webserver:
       meta-xfce:
-
-local_conf_header:
-  distro: |
-    ERROR_QA:remove = "license-exists"


### PR DESCRIPTION
If needed this ignore of this QA error should be set at recipe level.

What is already the case for openscenegraph:
  meta-ros2/recipes-support/openscenegraph/openscenegraph_3.6.5.bb:ERROR_QA:remove = "license-exists"

