### PR TITLE
[scarthgap] {jazzy} Use 3.x, not 4.x.y of cmake because gz_cmake_vendor-release uses 3.5.5

### DIFF
--- a/meta-ros2-jazzy/recipes-bbappends/gz-cmake-vendor/gz-cmake-vendor_0.0.10-1.bbappend
+++ b/meta-ros2-jazzy/recipes-bbappends/gz-cmake-vendor/gz-cmake-vendor_0.0.10-1.bbappend
@@ -3,7 +3,7 @@
 ROS_BUILD_DEPENDS += "gz-cmake3"
 
 # See CMakeLists.txt for details on why /usr/opt/gz_cmake_vendor/ is used
-FILES:${PN} += "${datadir}/gz/gz-cmake4/* \
+FILES:${PN} += "${datadir}/gz/gz-cmake3/* \
                 ${prefix}/opt/gz_cmake_vendor/extra_cmake/lib/cmake/gz-cmake/*"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Use 3.x, not 4.x.y of cmake because gz_cmake_vendor-release uses 3.5.5. This makes gz-cmake-vendor compile. 