### PR TITLE
[master] {common} libyaml: fixed cmake 4.0.3 issue

### DIFF
--- a/meta-ros-common/recipes-support/libyaml/libyaml_0.2.5.bb
+++ b/meta-ros-common/recipes-support/libyaml/libyaml_0.2.5.bb
@@ -19,7 +19,8 @@ inherit cmake
 
 EXTRA_OECMAKE += "-DINSTALL_CMAKE_DIR=lib/cmake/yaml \
                   -DBUILD_TESTING=OFF \
-                  -DBUILD_SHARED_LIBS=ON"
+                  -DBUILD_SHARED_LIBS=ON \
+                  -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 DISABLE_STATIC:class-nativesdk = ""
 DISABLE_STATIC:class-native = ""


### PR DESCRIPTION
Issue because Yocto/OE is not at cmake version 4.0.3

| CMake Error at CMakeLists.txt:2 (cmake_minimum_required):
|   Compatibility with CMake < 3.5 has been removed from CMake.
|
|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
|   to tell CMake that the project requires at least <min> but has been updated
|   to work with policies introduced by <max> or earlier.
|
|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.