### PR TITLE
[master] {common} cpptoml: fixed cmake 4.0.3 issue

### DIFF
--- a/meta-ros-common/recipes-devtools/cpptoml/cpptoml/0003-Fix-build-with-CMake-4.0.patch
+++ b/meta-ros-common/recipes-devtools/cpptoml/cpptoml/0003-Fix-build-with-CMake-4.0.patch
@@ -1,0 +1,24 @@
+From 01ed8b5645ef274f109ad4a8c4de92d10cf10c0b Mon Sep 17 00:00:00 2001
+From: Timo Gurr <timo.gurr@gmail.com>
+Date: Thu, 22 May 2025 21:25:51 +0200
+Subject: [PATCH] Fix build with CMake >= 4.0
+
+Upstream-Status: Submitted [https://github.com/skystrife/cpptoml/pull/132]
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ec25cc..dd98df7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.1.0)
++cmake_minimum_required(VERSION 3.10)
+ project(cpptoml)
+ 
+ set(cpptoml_VERSION 0.4.0)
+-- 
+2.39.5
+

--- a/meta-ros-common/recipes-devtools/cpptoml/cpptoml_0.1.1.bb
+++ b/meta-ros-common/recipes-devtools/cpptoml/cpptoml_0.1.1.bb
@@ -1,13 +1,14 @@
+SUMMARY = "cpptoml is a header-only library for parsing TOML"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=8739ce451f437fa9493b37a405fb16f1"
 
 SRC_URI = "gitsm://github.com/skystrife/cpptoml.git;protocol=https;branch=master \
            file://0001-Fix-build-with-gcc-11.patch \
-           file://0002-Fix-build-with-clang.patch"
+           file://0002-Fix-build-with-clang.patch \
+	   file://0003-Fix-build-with-CMake-4.0.patch"
 
 PV = "0.1.1+git"
 SRCREV = "fededad7169e538ca47e11a9ee9251bc361a9a65"
-
 
 inherit cmake
 


### PR DESCRIPTION

| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
|   Compatibility with CMake < 3.5 has been removed from CMake.
|
|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
|   to tell CMake that the project requires at least <min> but has been updated
|   to work with policies introduced by <max> or earlier.
|
|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
|
|
| -- Configuring incomplete, errors occurred!