### PR TITLE
[master] {common} gz-math: added version 8.2.0

### DIFF
--- a/meta-ros-common/recipes-devtools/gazebo/gz-math8_8.2.0.bb
+++ b/meta-ros-common/recipes-devtools/gazebo/gz-math8_8.2.0.bb
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 Wind River Systems, Inc.
+SUMMARY = "General purpose math library for robot applications."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2a461be67a1edf991251f85f3aadd1d0"
+
+SRC_URI = "git://github.com/gazebosim/gz-math.git;protocol=https;branch=gz-math8"
+
+SRCREV = "4b3b642a0fc2119df624968c7973b9e87f5925ee"
+
+DEPENDS = "\
+    gz-cmake4 \
+    gz-cmake4-native \
+    gz-utils3 \
+    libeigen \
+    python3 \
+    python3-pybind11 \
+    ruby \
+    swig-native \
+"
+
+inherit cmake python3targetconfig
+
+FILES:${PN} += "${libdir}/python/"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Needed for gz-math-vendor version 0.3.1 (@Rolling)

@robwoolley I left the older versions untouched.  I have no idea how to check if those are still needed for a ros/yocto combination.