### PR TITLE
[master] {common} console-bridge: fixed cmake 4.0.3 issue

### DIFF
--- a/meta-ros-common/recipes-extended/console-bridge/console-bridge_1.0.1.bb
+++ b/meta-ros-common/recipes-extended/console-bridge/console-bridge_1.0.1.bb
@@ -18,6 +18,7 @@ SRCREV = "0a6c16ed68750837c32ed1cedee9fca7d61d4364"
 ROS_BRANCH ?= "branch=master"
 SRC_URI = "git://github.com/ros/console_bridge;${ROS_BRANCH};protocol=https"
 
+EXTRA_OECMAKE = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 inherit cmake
 


### PR DESCRIPTION
| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
|   Compatibility with CMake < 3.5 has been removed from CMake.
|
|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
|   to tell CMake that the project requires at least <min> but has been updated
|   to work with policies introduced by <max> or earlier.
|
|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.