### PR TITLE
[master] {common} zziplib: version bump 0.13.74 -> 0.13.80

### DIFF
--- a/meta-ros-common/recipes-support/zziplib/zziplib_0.13.80.bb
+++ b/meta-ros-common/recipes-support/zziplib/zziplib_0.13.80.bb
@@ -7,9 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=55ca817ccb7d5b5b66355690e9abc605 \
 
 SRC_URI = "git://github.com/gdraheim/zziplib;protocol=https;branch=master"
 
-PV = "0.13.74+git"
-SRCREV = "df9e9c06634cb0c48bdc42efe9f7ac55847503a5"
-
+SRCREV = "57d5394a2a36b00c65d7979676e18bca14e94be0"
 
 DEPENDS = "zlib libsdl2"
 


### PR DESCRIPTION
- removed the +git from PV the SCREV is the one of the release
- cmake 4.0.3 issue at 0.13.74 is solved in 0.13.80