### PR TITLE
[master] {common} bullet: Allow to build with CMake 4+

### DIFF
--- a/meta-ros-common/recipes-extended/bullet/bullet_2.89.bb
+++ b/meta-ros-common/recipes-extended/bullet/bullet_2.89.bb
@@ -1,7 +1,4 @@
 # Copyright (c) 2020 LG Electronics, Inc.
-#
-# Similar to meta-ros1/recipes-extended/bullet/bullet_2.87.bb
-# but newer version without python2 support
 
 DESCRIPTION = "Real-time collision detection and multi-physics simulation"
 HOMEPAGE = "https://github.com/bulletphysics/bullet3"
@@ -25,6 +22,3 @@ EXTRA_OECMAKE += "-DBUILD_BULLET2_DEMOS=OFF"
 
 # Fails to find -lBussIK
 EXTRA_OECMAKE += "-DBUILD_UNIT_TESTS=OFF"
-
-#CFLAGS += "-fsigned-char"
-#CXXFLAGS += "-fsigned-char"

--- a/meta-ros-common/recipes-extended/bullet/bullet_2.89.bb
+++ b/meta-ros-common/recipes-extended/bullet/bullet_2.89.bb
@@ -16,6 +16,7 @@ inherit cmake
 
 EXTRA_OECMAKE = "-DUSE_DOUBLE_PRECISION=ON -DCMAKE_BUILD_TYPE=Release"
 EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=ON -DINSTALL_LIBS=ON -DINSTALL_EXTRA_LIBS=ON"
+EXTRA_OECMAKE += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 # Tries to link with prebuilt x86 libraries e.g.
 # aarch64-oe-linux/9.3.0/ld: skipping incompatible


### PR DESCRIPTION
|   Compatibility with CMake < 3.5 has been removed from CMake.
|
|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
|   to tell CMake that the project requires at least <min> but has been updated
|   to work with policies introduced by <max> or earlier.
|
|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

And removed some no longer relevant comments.