### PR TITLE
[master] {common} tvm: fixed branch, cmake + destsuffix for Yocto master

### DIFF
--- a/meta-ros-common/recipes-devtools/tvm/tvm_0.7.0.bb
+++ b/meta-ros-common/recipes-devtools/tvm/tvm_0.7.0.bb
@@ -15,10 +15,10 @@ SRCREV_vta-hw = "87ce9acfae550d1a487746e9d06c2e250076e54c"
 SRCREV_FORMAT = "tvm_dlmc-core_dlpack_rang_vta-hw"
 
 SRC_URI = "git://github.com/apache/tvm;name=tvm;branch=main;protocol=https \
-    git://github.com/dmlc/dmlc-core;name=dlmc-core;destsuffix=git/3rdparty/dmlc-core;branch=master;protocol=https \
-    git://github.com/dmlc/dlpack;name=dlpack;destsuffix=git/3rdparty/dlpack;branch=master;protocol=https \
-    git://github.com/agauniyal/rang;name=rang;destsuffix=git/3rdparty/rang;branch=master;protocol=https \
-    git://github.com/apache/incubator-tvm-vta;name=vta-hw;destsuffix=git/3rdparty/vta-hw;branch=master;protocol=https \
+    git://github.com/dmlc/dmlc-core;name=dlmc-core;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/3rdparty/dmlc-core;branch=main;protocol=https \
+    git://github.com/dmlc/dlpack;name=dlpack;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/3rdparty/dlpack;branch=master;protocol=https \
+    git://github.com/agauniyal/rang;name=rang;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/3rdparty/rang;branch=master;protocol=https \
+    git://github.com/apache/incubator-tvm-vta;name=vta-hw;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/3rdparty/vta-hw;branch=master;protocol=https \
 "
 
 


### PR DESCRIPTION
- github.com/dmlc/dmlc-core: project moved from master to main branch

  ERROR: tvm-0.7.0-r0 do_fetch: Fetcher failure: Unable to find revision 6c401e242c59a1f4c913918246591bb13fd714e7 in branch master even from upstream

- Changed destsuffix=git to  destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX} to fix:

  | .../tvm/0.7.0/sources/tvm-0.7.0/include/tvm/runtime/container.h:27:10: fatal error: dmlc/logging.h: No such file or directory
  |    27 | #include <dmlc/logging.h>
  |       |          ^~~~~~~~~~~~~~~~

- fix for cmake version requirement

  | CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  |   Compatibility with CMake < 3.5 has been removed from CMake.
  |
  |   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  |   to tell CMake that the project requires at least <min> but has been updated
  |   to work with policies introduced by <max> or earlier.
  |
  |   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.