### PR TITLE
[master] {common} orocos-kdl: Allow to build with CMake 4+

### DIFF
--- a/meta-ros-common/recipes-orocos-kdl/orocos-kdl/orocos-kdl_1.5.1-87.bb
+++ b/meta-ros-common/recipes-orocos-kdl/orocos-kdl/orocos-kdl_1.5.1-87.bb
@@ -2,7 +2,7 @@ LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=a8ffd58e6eb29a955738b8fcc9e9e8f2 \
                     file://debian/copyright;md5=57b48fd56cf39965622e7d8a9ff2ed50"
 
-SRC_URI = " \
+SRC_URI = "\
     git://github.com/orocos/orocos_kinematics_dynamics.git;protocol=https;branch=master \
     file://0001-CMakeLists.txt-fixing-install-location-of-cmake-conf.patch \
     file://0001-CMakeLists.txt-resolving-host-path-injection-in-.pc-.patch \
@@ -12,9 +12,9 @@ SRCREV = "129693e571a7822655d1f58bb0f83b385542a3d8"
 
 S = "${UNPACKDIR}/${BPN}-${PV}/orocos_kdl"
 
-DEPENDS = " \
-    libeigen \
+DEPENDS = "\
     boost \
+    libeigen \
 "
 
 inherit cmake

--- a/meta-ros-common/recipes-orocos-kdl/orocos-kdl/orocos-kdl_1.5.1-87.bb
+++ b/meta-ros-common/recipes-orocos-kdl/orocos-kdl/orocos-kdl_1.5.1-87.bb
@@ -17,4 +17,6 @@ DEPENDS = "\
     libeigen \
 "
 
+EXTRA_OECMAKE = "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
 inherit cmake


### PR DESCRIPTION
+ some oelint fixes