### PR TITLE
[master]{rolling} lely-core: version bump 2.3.2 -> 2.3.5

### DIFF
--- a/meta-ros2-rolling/recipes-bbappends/ros2-canopen/lely-core-libraries/add-target.patch
+++ b/meta-ros2-rolling/recipes-bbappends/ros2-canopen/lely-core-libraries/add-target.patch
@@ -11,13 +11,13 @@ Index: git/CMakeLists.txt
 ===================================================================
 --- git.orig/CMakeLists.txt
 +++ git/CMakeLists.txt
-@@ -14,14 +14,26 @@ install(
+@@ -15,14 +15,26 @@ install(
  
  ament_python_install_package(cogen SKIP_COMPILE SCRIPTS_DESTINATION lib/cogen)
  
 +add_library(${PROJECT_NAME} INTERFACE)
 +
-+target_link_libraries(${PROJECT_NAME} INTERFACE lely-can lely-co lely-coapp lely-ev lely-io2 lely-io lely-libc lely-tap lely-util)
++target_link_libraries(${PROJECT_NAME} INTERFACE lely-can lely-co lely-coapp lely-ev lely-io2 lely-libc lely-tap lely-util)
 +
  # install entry-point script(s) in bin as well
  install(
@@ -26,7 +26,7 @@ Index: git/CMakeLists.txt
      USE_SOURCE_PERMISSIONS)
  
 -ament_export_include_directories(include)
--ament_export_libraries(lely-can lely-co lely-coapp lely-ev lely-io2 lely-io lely-libc lely-tap lely-util)
+-ament_export_libraries(lely-can lely-co lely-coapp lely-ev lely-io2 lely-libc lely-tap lely-util)
 +install(
 +    TARGETS ${PROJECT_NAME}
 +    EXPORT export_${PROJECT_NAME}

--- a/meta-ros2-rolling/recipes-bbappends/ros2-canopen/lely-core-libraries/use-system-lely-core.patch
+++ b/meta-ros2-rolling/recipes-bbappends/ros2-canopen/lely-core-libraries/use-system-lely-core.patch
@@ -19,7 +19,7 @@ Index: git/CMakeLists.txt
 -  INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"  # Installation prefix
 -  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build
 -  GIT_REPOSITORY https://gitlab.com/lely_industries/lely-core.git
--  GIT_TAG b63a0b6f79d3ea91dc221724b42dae49894449fc
+-  GIT_TAG fb735b79cab5f0cdda45bc5087414d405ef8f3ab
 -  TIMEOUT 60
 -  #UPDATE step apply patch to fix dcf-tools install
 -  UPDATE_COMMAND

--- a/meta-ros2-rolling/recipes-bbappends/ros2-canopen/lely-core-libraries_0.3.1-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/ros2-canopen/lely-core-libraries_0.3.1-1.bbappend
@@ -5,8 +5,6 @@ SRC_URI += "file://use-system-lely-core.patch \
             file://skip-compile-cogen.patch \
             file://add-target.patch"
 
-SRCREV_upstream = "7824cbb2ac08d091c4fa2fb397669b938de9e3f5"
-
 DEPENDS += "lely-core lely-core-native"
 
 # CMake Error:

--- a/meta-ros2/recipes-support/lely-core/lely-core/0001-fix-GCC-15-errors.patch
+++ b/meta-ros2/recipes-support/lely-core/lely-core/0001-fix-GCC-15-errors.patch
@@ -1,0 +1,64 @@
+From 0b1daefaab1d88999f5e0ac24f5a38644eeca17a Mon Sep 17 00:00:00 2001
+From: "J. S. Seldenthuis" <jseldenthuis@lely.com>
+Date: Tue, 8 Jul 2025 17:15:14 +0200
+Subject: [PATCH] fix GCC 15 errors
+
+Upstream-Status: Backport [https://gitlab.com/lely_industries/lely-core/-/commit/6ed995fa86d828957b636a11470f150830d877ec]
+
+---
+ include/lely/libc/stdatomic.h | 8 +++++++-
+ src/util/print.c              | 4 ++--
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/include/lely/libc/stdatomic.h b/include/lely/libc/stdatomic.h
+index 841d1baf..4b35ed97 100644
+--- a/include/lely/libc/stdatomic.h
++++ b/include/lely/libc/stdatomic.h
+@@ -3,7 +3,7 @@
+  * includes `<stdatomic.h>`, if it exists, and defines any missing
+  * functionality.
+  *
+- * @copyright 2013-2018 Lely Industries N.V.
++ * @copyright 2013-2025 Lely Industries N.V.
+  *
+  * @author J. S. Seldenthuis <jseldenthuis@lely.com>
+  *
+@@ -32,7 +32,13 @@
+ #endif // !LELY_HAVE_STDATOMIC_H
+ 
+ #if LELY_HAVE_STDATOMIC_H
++
+ #include <stdatomic.h>
++
++#ifndef ATOMIC_VAR_INIT
++#define ATOMIC_VAR_INIT(value) (value)
++#endif
++
+ #else // !LELY_HAVE_STDATOMIC_H
+ 
+ #if defined(__clang__) && __has_extension(c_atomic)
+diff --git a/src/util/print.c b/src/util/print.c
+index 94d8aa59..99779ad1 100644
+--- a/src/util/print.c
++++ b/src/util/print.c
+@@ -4,7 +4,7 @@
+  *
+  * @see lely/util/print.h
+  *
+- * @copyright 2017-2019 Lely Industries N.V.
++ * @copyright 2017-2025 Lely Industries N.V.
+  *
+  * @author J. S. Seldenthuis <jseldenthuis@lely.com>
+  *
+@@ -262,7 +262,7 @@ size_t
+ print_base64(char **pbegin, char *end, const void *ptr, size_t n)
+ {
+ 	// clang-format off
+-	static const char tab[64] =
++	static const char tab[] =
+ 			"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef"
+ 			"ghijklmnopqrstuvwxyz0123456789+/";
+ 	// clang-format on
+-- 
+2.43.0
+

--- a/meta-ros2/recipes-support/lely-core/lely-core_2.3.5.bb
+++ b/meta-ros2/recipes-support/lely-core/lely-core_2.3.5.bb
@@ -4,10 +4,10 @@ DESCRIPTION = "A collection of C and C++ libraries and tools, providing hih-perf
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-SRC_URI = "git://gitlab.com/lely_industries/lely-core.git;protocol=https;branch=v2.3"
+SRC_URI = "git://gitlab.com/lely_industries/lely-core.git;protocol=https;branch=v2.3 \
+    file://0001-fix-GCC-15-errors.patch"
 
-PV = "2.3.2+git${SRCPV}"
-SRCREV = "7824cbb2ac08d091c4fa2fb397669b938de9e3f5"
+SRCREV = "9e3267d26018f6f6babd50786f6ae2af89cc57ea"
 
 
 inherit pkgconfig autotools setuptools3-base


### PR DESCRIPTION
+ added a backported patch to fix the GCC 15 issues
+ removed not longer needed -Wno-error flag