### PR TITLE
{rolling}: changed meta-scipy by new meta-python-ai

### DIFF
--- a/meta-ros2-rolling/conf/ros-distro/include/rolling/ros-distro.inc
+++ b/meta-ros2-rolling/conf/ros-distro/include/rolling/ros-distro.inc
@@ -171,8 +171,8 @@ ROS_WORLD_SKIP_GROUPS += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'clang-laye
 # recipes depending on cargo which could be provided by cargo@meta-rust or oe-core[honister] and newer release (where it was imported from meta-rust)
 ROS_WORLD_SKIP_GROUPS += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'rust-layer', '', 'cargo', d)}"
 
-# recipes depending on scipy which could be provided by python3-scipy@meta-scipy
-ROS_WORLD_SKIP_GROUPS += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-scipy', '', 'scipy', d)}"
+# recipes depending on scipy which could be provided by python3-scipy@meta-python-ai
+ROS_WORLD_SKIP_GROUPS += "${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-python-ai', '', 'scipy', d)}"
 
 # swri recipes depending on marti-*-msgs, currently broken after to https://github.com/ros/rosdistro/commit/e019cc8729e7ff2ba2ed51e63886734936254111
 ROS_WORLD_SKIP_GROUPS += "swri"


### PR DESCRIPTION
@robwoolley I assume this one is also needed with the change from meta-scipy to meta-python-ai?


As meta-ros (and kas) is now using the more maintained meta-python-ai layer.

ERROR: Nothing RPROVIDES 'pinocchio' (but ../layers/meta-ros/meta-ros2-rolling/recipes-core/packagegroups/packagegroup-ros-world-rolling.bb, ../layers/meta-ros/meta-ros2-rolling/generated-recipes/tsid/tsid_1.8.0-1.bb, layers/meta-ros/meta-ros2-rolling/generated-recipes/kinematics-interface-pinocchio/kinematics-interface-pinocchio_0.0.1-1.bb RDEPENDS on or otherwise requires it)
pinocchio was skipped: Recipe will be skipped because: pinocchio: depends on eigenpy which depends on python3-scipy which requires meta-scipy layer