### PR TITLE
[master]{common} ipopt: fixed creation of M4 install directory

### DIFF
--- a/meta-ros-common/recipes-support/ipopt/ipopt_3.14.16.bb
+++ b/meta-ros-common/recipes-support/ipopt/ipopt_3.14.16.bb
@@ -15,6 +15,6 @@ EXTRA_OECONF = "\
 "
 
 do_configure:prepend () {
-    mkdir -p ${S}/coinor-m4
+    mkdir -p ${STAGING_DATADIR_NATIVE}/aclocal
     cp ${STAGING_DIR_NATIVE}/${datadir}/coinor/* ${STAGING_DATADIR_NATIVE}/aclocal
 }


### PR DESCRIPTION
Cleaned up code left over from commit 1b7ea4ce013c94d6712e1978c31c7dadaae01a4e
    {common} ipopt: fixed the m4 macro path