### PR TITLE
[master]{rolling} python3-pygraphviz: lock the version of graphviz at…

### DIFF
--- a/meta-ros2-kilted/conf/ros-distro/include/kilted/ros-distro-preferred-versions.inc
+++ b/meta-ros2-kilted/conf/ros-distro/include/kilted/ros-distro-preferred-versions.inc
@@ -36,3 +36,6 @@ PREFERRED_VERSION_gz-transport14 = "14.0.1"
 PREFERRED_VERSION_gz-utils3 = "3.1.1"
 
 PREFERRED_VERSION_ogre-next = "2.3.3"
+
+# python-pygraphviz needed a version < 13
+PREFERRED_VERSION_graphviz = "12.2.1"

--- a/meta-ros2-rolling/conf/ros-distro/include/rolling/ros-distro-preferred-versions.inc
+++ b/meta-ros2-rolling/conf/ros-distro/include/rolling/ros-distro-preferred-versions.inc
@@ -16,3 +16,6 @@ PREFERRED_VERSION_sdformat = "15.3.0"
 
 # required for python3-scipy
 PREFERRED_VERSION_python3-gast = "0.6.0"
+
+# python-pygraphviz needed a version < 13
+PREFERRED_VERSION_graphviz = "12.2.1"

--- a/meta-ros2/recipes-graphics/graphviz/graphviz/graphviz-setup.sh
+++ b/meta-ros2/recipes-graphics/graphviz/graphviz/graphviz-setup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo "Setting up graphviz..."
+
+# Create /usr/lib/graphviz/config6
+$OECORE_NATIVE_SYSROOT/usr/bin/dot -c

--- a/meta-ros2/recipes-graphics/graphviz/graphviz_12.2.1.bb
+++ b/meta-ros2/recipes-graphics/graphviz/graphviz_12.2.1.bb
@@ -1,0 +1,120 @@
+SUMMARY = "Graph Visualization Tools"
+HOMEPAGE = "http://www.graphviz.org"
+LICENSE = "EPL-1.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=9109f5fc16cf963fb3cdd32781b3ce04"
+
+DEPENDS = " \
+    bison-native \
+    groff-native \
+    libtool \
+    gdk-pixbuf \
+    cairo \
+    pango \
+    expat \
+    freetype \
+"
+DEPENDS:append:class-target = " ${BPN}-native"
+DEPENDS:append:class-nativesdk = " ${BPN}-native"
+
+inherit autotools-brokensep pkgconfig gettext qemu
+
+SRC_URI = "https://gitlab.com/api/v4/projects/4207231/packages/generic/${BPN}-releases/${PV}/${BP}.tar.xz \
+           "
+SRC_URI:append:class-nativesdk = "\
+           file://graphviz-setup.sh \
+"
+SRC_URI[sha256sum] = "85e34b5c982777c30f01dfab9ea7c713b4335a2f584e62c0abb9868413eb915b"
+
+UPSTREAM_CHECK_URI = "https://graphviz.org/download/"
+UPSTREAM_CHECK_REGEX = "(?P<pver>\d+(\.\d+)+)"
+
+PACKAGECONFIG ??= "librsvg"
+PACKAGECONFIG[librsvg] = "--with-librsvg,--without-librsvg,librsvg"
+
+EXTRA_OECONF:append = " PS2PDF=/bin/echo --disable-man-pdfs"
+
+EXTRA_OECONF:class-target = "\
+                --with-expatincludedir=${STAGING_INCDIR} \
+                --with-expatlibdir=${STAGING_LIBDIR} \
+                --without-included-ltdl \
+                --disable-java \
+                --disable-perl \
+                --disable-tcl \
+                --disable-r \
+                --disable-sharp \
+                "
+EXTRA_OECONF:class-nativesdk = "\
+                --with-expatincludedir=${STAGING_INCDIR} \ 
+                --with-expatlibdir=${STAGING_LIBDIR} \
+                --without-included-ltdl \
+                --disable-java \
+                --disable-tcl \
+                --disable-r \
+                --disable-sharp \
+                "
+EXTRA_OECONF:class-native = "\
+                --disable-tcl \
+                "
+CFLAGS:append:class-target = " -D_typ_ssize_t=1 -D_long_double=1"
+CFLAGS:append:class-nativesdk = " -D_typ_ssize_t=1 -D_long_double=1"
+do_configure:prepend() {
+    cd ${S}
+    # create version.m4 and ignore libtoolize errors
+    ./autogen.sh NOCONFIG || true
+}
+
+do_install:append:class-nativesdk() {
+    # graphviz-setup.sh must be executed at SDK installation
+    install -d ${D}${SDKPATHNATIVE}/post-relocate-setup.d
+    install -m 0755 ${UNPACKDIR}/graphviz-setup.sh ${D}${SDKPATHNATIVE}/post-relocate-setup.d
+}
+FILES:${PN}:class-nativesdk += "${SDKPATHNATIVE}"
+
+# create /usr/lib/graphviz/config6
+graphviz_sstate_postinst() {
+    mkdir -p ${SYSROOT_DESTDIR}${bindir}
+    dest=${SYSROOT_DESTDIR}${bindir}/postinst-${PN}
+    echo '#!/bin/sh' > $dest
+    echo '' >> $dest
+    echo 'dot -c' >> $dest
+    chmod 0755 $dest
+}
+SYSROOT_PREPROCESS_FUNCS:append:class-native = " graphviz_sstate_postinst"
+
+pkg_postinst:${PN} () {
+    if [ -n "$D" ]; then
+        if ${@bb.utils.contains('MACHINE_FEATURES', 'qemu-usermode', 'true', 'false', d)}; then
+            ${@qemu_run_binary(d, '$D', '${bindir}/dot')} -c
+        fi
+    else
+        dot -c
+    fi
+}
+
+pkg_postrm:${PN} () {
+    rm -f $D${libdir}/graphviz/config*
+    rmdir --ignore-fail-on-non-empty $D${libdir}/graphviz
+}
+
+PACKAGE_WRITE_DEPS += "qemu-native"
+
+PACKAGES =+ "${PN}-python ${PN}-perl ${PN}-demo"
+
+FILES:${PN}-python += "${PYTHON_SITEPACKAGES_DIR}/ ${libdir}/graphviz/python/"
+FILES:${PN}-perl += "${libdir}/perl5/*/vendor_perl/ ${libdir}/graphviz/perl/"
+FILES:${PN}-demo += "${datadir}/graphviz/demo/"
+
+RDEPENDS:${PN}-perl += "perl"
+RDEPENDS:${PN}-python += "python3"
+RDEPENDS:${PN}-demo += "python3 perl"
+
+RRECOMMENDS:${PN} = "liberation-fonts"
+
+INSANE_SKIP:${PN}-perl = "dev-so"
+INSANE_SKIP:${PN}-python = "dev-so"
+
+FILES_SOLIBSDEV:append = " ${libdir}/graphviz/lib*${SOLIBSDEV}"
+
+RRECOMMENDS:${PN} = "liberation-fonts"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
… 12.2.1

Lock the version of graphviz at 12.2.1.  And added graphviz recipe at that version from meta-openembedded/meta-oe in meta-ros.

The version in meta-openembedded went to 13.1.0.
And python-pygraphviz is not yet compatible with >13. @see: https://github.com/pygraphviz/pygraphviz/pull/566