### PR TITLE
[master]{rolling} qt-qui-cpp: missing python pip added

### DIFF
--- a/meta-ros2-rolling/recipes-bbappends/qt-gui-core/qt-gui-cpp_2.10.1-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/qt-gui-core/qt-gui-cpp_2.10.1-1.bbappend
@@ -7,6 +7,8 @@ inherit ${@bb.utils.contains('BBFILE_COLLECTIONS', 'qt5-layer', 'qmake5_base', '
 
 inherit python3native
 
+DEPENDS += "python3-pip-native"
+
 export SIP_PROJECT_INCLUDE_DIRS = "${STAGING_DIR_TARGET}/${libdir}/${PYTHON_DIR}/site-packages/PyQt5/bindings"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"


### PR DESCRIPTION
Pip was missing in qt-gui-cpp.
patch needed at Master/Rolling