### PR TITLE
[scarthgap]{common} Fix build issues of tvm_0.7.0.bb and python3-transforms3d_0.3.1.bb

### DIFF
--- a/meta-ros-common/recipes-devtools/python/python3-transforms3d/0001-fix-obsolete-contents-of-configparser.patch
+++ b/meta-ros-common/recipes-devtools/python/python3-transforms3d/0001-fix-obsolete-contents-of-configparser.patch
@@ -1,0 +1,28 @@
+From 6a17b30b4dab8d589675a6deb51f6798dd551e27 Mon Sep 17 00:00:00 2001
+From: Albert Han <rw0501610@163.com>
+Date: Fri, 15 Aug 2025 01:31:33 +0800
+Subject: [PATCH] fix obsolete contents of configparser
+
+---
+ versioneer.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/versioneer.py b/versioneer.py
+index 03b9a96..c98beeb 100644
+--- a/versioneer.py
++++ b/versioneer.py
+@@ -335,9 +335,9 @@ def get_config_from_root(root):
+     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
+     # the top of versioneer.py for instructions on writing your setup.cfg .
+     setup_cfg = os.path.join(root, "setup.cfg")
+-    parser = configparser.SafeConfigParser()
++    parser = configparser.ConfigParser()
+     with open(setup_cfg, "r") as f:
+-        parser.readfp(f)
++        parser.read_file(f)
+     VCS = parser.get("versioneer", "VCS")  # mandatory
+ 
+     def get(parser, name):
+-- 
+2.43.0
+

--- a/meta-ros-common/recipes-devtools/python/python3-transforms3d_0.3.1.bb
+++ b/meta-ros-common/recipes-devtools/python/python3-transforms3d_0.3.1.bb
@@ -7,6 +7,8 @@ LIC_FILES_CHKSUM = "file://setup.py;beginline=36;endline=36;md5=6dd3a8a8bcf9d24e
 
 SRC_URI[sha256sum] = "404c7797c78aa461cb8043081901fc5517cef342d5ff56becd74a7967ba88d78"
 
+SRC_URI += "file://0001-fix-obsolete-contents-of-configparser.patch"
+
 inherit pypi setuptools3
 
 RDEPENDS:${PN} += "\

--- a/meta-ros-common/recipes-devtools/tvm/tvm_0.7.0.bb
+++ b/meta-ros-common/recipes-devtools/tvm/tvm_0.7.0.bb
@@ -15,7 +15,7 @@ SRCREV_vta-hw = "87ce9acfae550d1a487746e9d06c2e250076e54c"
 SRCREV_FORMAT = "tvm_dlmc-core_dlpack_rang_vta-hw"
 
 SRC_URI = "git://github.com/apache/tvm;name=tvm;branch=main;protocol=https \
-    git://github.com/dmlc/dmlc-core;name=dlmc-core;destsuffix=git/3rdparty/dmlc-core;branch=master;protocol=https \
+    git://github.com/dmlc/dmlc-core;name=dlmc-core;destsuffix=git/3rdparty/dmlc-core;branch=main;protocol=https \
     git://github.com/dmlc/dlpack;name=dlpack;destsuffix=git/3rdparty/dlpack;branch=master;protocol=https \
     git://github.com/agauniyal/rang;name=rang;destsuffix=git/3rdparty/rang;branch=master;protocol=https \
     git://github.com/apache/incubator-tvm-vta;name=vta-hw;destsuffix=git/3rdparty/vta-hw;branch=master;protocol=https \


### PR DESCRIPTION
**The first commit is aim to solve the issue of tvm**
`github.com/dmlc/dmlc-core` the branch of it has changed from `master` to `main`
```
ERROR: tvm-0.7.0-r0 do_fetch: Fetcher failure: Unable to find revision 6c401e242c59a1f4c913918246591bb13fd714e7 in branch master even from upstream
```

**The second commit is aim to solve the issue of python3-transforms3d**
The SafeConfigParser and readfp in configparser are obsolete (https://docs.python.org/3.12/whatsnew/3.12.html#configparser).
```
but python3-transforms3d still uses them, it will lead to build error.
|     parser = configparser.SafeConfigParser()
|              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
| AttributeError: module 'configparser' has no attribute 'SafeConfigParser'. Did you mean: 'RawConfigParser'?
| ERROR: 'python3 setup.py bdist_wheel ' execution failed.
```