### PR TITLE
[master]{ros2} ament_cmake: add python configurations for class-target

### DIFF
--- a/meta-ros2/classes/ros_ament_cmake.bbclass
+++ b/meta-ros2/classes/ros_ament_cmake.bbclass
@@ -29,6 +29,28 @@ export AMENT_PREFIX_PATH = "${STAGING_DIR_HOST}${prefix};${STAGING_DIR_NATIVE}${
 
 inherit cmake python3native
 
+EXTRA_PYTHON_DEPENDS ?= ""
+EXTRA_PYTHON_DEPENDS:class-target = "python3"
+DEPENDS:append = " ${EXTRA_PYTHON_DEPENDS}"
+setup_target_config() {
+        export _PYTHON_SYSCONFIGDATA_NAME="_sysconfigdata"
+        export _PYTHON_PROJECT_BASE="${B}"
+        export PYTHONPATH=${STAGING_LIBDIR}/python-sysconfigdata:$PYTHONPATH
+        export PATH=${STAGING_EXECPREFIXDIR}/python-target-config/:$PATH
+}
+
+do_configure:prepend:class-target() {
+        setup_target_config
+}
+
+do_compile:prepend:class-target() {
+        setup_target_config
+}
+
+do_install:prepend:class-target() {
+        setup_target_config
+}
+
 FILES:${PN}:prepend = " \
     ${datadir}/ament_index \
 "


### PR DESCRIPTION
 Add target configurations for fixing wrong PYTHONSOABI of python c libraries in rosbag2_py.


## Issue: runtime error of rosbag2
```
root@qcs6490-rb3gen2-core-kit:/# ros2 bag -h
Failed to load entry point 'burst': No module named 'rosbag2_py._compression_options'
Failed to load entry point 'convert': No module named 'rosbag2_py._compression_options'
Failed to load entry point 'info': No module named 'rosbag2_py._compression_options'
Failed to load entry point 'play': No module named 'rosbag2_py._compression_options'
Failed to load entry point 'record': No module named 'rosbag2_py._compression_options'
Failed to load entry point 'reindex': No module named 'rosbag2_py._compression_options'
usage: ros2 bag [-h] Call `ros2 bag <command> -h` for more detailed usage. ...
```

## Root Cause
Because the target configuration is missing, the Python interpreter reads PYTHON_SOABI from the host (x86_64), which results in incorrectly named(x86_64) libraries.

```
ls /usr/ros/jazzy/lib/python3.14/site-packages/rosbag2_py/
__init__.py                                           _reader.pyi
__init__.pyi                                          _reindexer.cpython-314-x86_64-linux-gnu.so
__pycache__                                           _reindexer.pyi
_compression_options.cpython-314-x86_64-linux-gnu.so  _storage.cpython-314-x86_64-linux-gnu.so
_compression_options.pyi                              _storage.pyi
_info.cpython-314-x86_64-linux-gnu.so                 _transport.cpython-314-x86_64-linux-gnu.so
_info.pyi                                             _transport.pyi
_message_definitions.cpython-314-x86_64-linux-gnu.so  _writer.cpython-314-x86_64-linux-gnu.so
_message_definitions.pyi                              _writer.pyi
_reader.cpython-314-x86_64-linux-gnu.so               py.typed
```

