### PR TITLE
[master]{common} boost: Stop requiring NumPy for Boost.Python

### DIFF
--- a/meta-ros-common/recipes-support/boost/boost_%.bbappend
+++ b/meta-ros-common/recipes-support/boost/boost_%.bbappend
@@ -2,11 +2,8 @@
 
 inherit python3native
 
-DEPENDS += "python3-numpy-native"
-
 FILES:${PN}-python = " \
     ${libdir}/libboost_python*.so.* \
-    ${libdir}/libboost_numpy*.so.* \
 "
 
 do_configure() {


### PR DESCRIPTION
## Description

This PR removes the `python3-numpy-native` dependency from boost. It should instead be added by downstream consumers of boost.

Boost.Python can be built without NumPy. The meta-ros Boost append adds `python3-numpy-native` unconditionally and packages `libboost_numpy` with the Boost.Python package, causing unrelated Boost users to depend on NumPy.

Only package Boost.Python here. Recipes that require Boost.NumPy should enable and depend on it explicitly instead of making all Boost users depend on NumPy.

## Motivation and context

It was increasing the time of my build without ROS, from 63mins 50s, to 64mins, 32s.

## How has this been tested?

Tested on my work OS, based on Scarthgap, with this change backported.

### Before

* Build tasks: 7293
* Build time: 64mins 32s

### After

* Build tasks: 7279
* Build time: 63mins 50s

### Additional verification: Remove meta-ros entirely

* Tasks: 7278
* Build time: 63min 52s

(The final task I traced down to a summary or benign action or something.)

### Additional verification: Blocklist `python3-numpy-native`

To scrutinize the size of my OTA, I did:

```bitbake
SKIP_RECIPE[python3-numpy-native] = "${@'python3-numpy-native is not allowed.' if d.getVar('BUILD_DEVELOPMENT') == '0' else ''}"
```

Before:

My build failed because boost pulled in `python3-numpy-native`.

After:

Build succeeded because numpy-native wasn't built.