### PR TITLE
[wrynose]{common}{lyrical}{rolling}{ros2} Lyrical base build and rqt icon fixes

### DIFF
--- a/meta-ros-common/conf/ros-distro/include/enable-fortran.inc
+++ b/meta-ros-common/conf/ros-distro/include/enable-fortran.inc
@@ -6,4 +6,3 @@
 # Note this is not officially supported by OpenEmbedded.
 FORTRAN:forcevariable = "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'fortran', '', ',fortran', d)}"
 RUNTIMETARGET:append:pn-gcc-runtime = "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'fortran', '', ' libquadmath', d)}"
-HOSTTOOLS += "${@bb.utils.contains('ROS_WORLD_SKIP_GROUPS', 'fortran', '', 'gfortran', d)}"

--- a/meta-ros2-lyrical/recipes-bbappends/osrf-pycommon/osrf-pycommon_2.1.7-3.bbappend
+++ b/meta-ros2-lyrical/recipes-bbappends/osrf-pycommon/osrf-pycommon_2.1.7-3.bbappend
@@ -1,6 +1,6 @@
-PACKAGES += "${PYTHON_PN}-${PN}"
+PACKAGES =+ "${PYTHON_PN}-${BPN}"
 
 FILES:${PN} += "${datadir}/ament_index/resource_index/packages/osrf_pycommon"
-FILES:${PYTHON_PN}-${PN} = "${PYTHON_SITEPACKAGES_DIR}/*"
+FILES:${PYTHON_PN}-${BPN} = "${PYTHON_SITEPACKAGES_DIR}/*"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros2-rolling/recipes-bbappends/osrf-pycommon/osrf-pycommon_2.1.7-1.bbappend
+++ b/meta-ros2-rolling/recipes-bbappends/osrf-pycommon/osrf-pycommon_2.1.7-1.bbappend
@@ -1,6 +1,6 @@
-PACKAGES += "${PYTHON_PN}-${PN}"
+PACKAGES =+ "${PYTHON_PN}-${BPN}"
 
 FILES:${PN} += "${datadir}/ament_index/resource_index/packages/osrf_pycommon"
-FILES:${PYTHON_PN}-${PN} = "${PYTHON_SITEPACKAGES_DIR}/*"
+FILES:${PYTHON_PN}-${BPN} = "${PYTHON_SITEPACKAGES_DIR}/*"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/meta-ros2/dynamic-layers/meta-qt6/recipes-python/pyqt6/python3-pyqt6_%.bbappend
+++ b/meta-ros2/dynamic-layers/meta-qt6/recipes-python/pyqt6/python3-pyqt6_%.bbappend
@@ -1,2 +1,6 @@
 # Copyright (c) 2026 Wind River Systems, Inc.
 PYQT_MODULES:append = " QtWidgets"
+
+# Enable QtSvg module for SVG icon rendering in ROS rqt
+PYQT_MODULES:append = " QtSvg"
+DEPENDS += "qtsvg"

--- a/meta-ros2/dynamic-layers/meta-qt6/recipes-python/pyqt6/python3-pyqt6_%.bbappend
+++ b/meta-ros2/dynamic-layers/meta-qt6/recipes-python/pyqt6/python3-pyqt6_%.bbappend
@@ -1,2 +1,6 @@
 # Copyright (c) 2026 Wind River Systems, Inc.
-PYQT_MODULES:append = " QtWidgets"
+
+DEPENDS += "qtsvg"
+
+# Enable QtSvg module for SVG icon rendering in ROS rqt
+PYQT_MODULES:append = " QtSvg QtWidgets"


### PR DESCRIPTION
Base: `ros/meta-ros` `wrynose` (tip `2ebdb0b8691a`)
Head: `twoerner:twoerner/20260804-qt6` (4 commits ahead / 0 behind once the 
Rolling patch is applied; was verified at `9b44dae75d2b` with the first three)

---

Four fixes. Three came out of building the ROS 2 Lyrical base and demo
package set on current OpenEmbedded; the fourth carries one of them
across to Rolling, which has the identical defect.

### 1. `{common} enable-fortran: rely on the cross-toolchain`

`enable-fortran.inc` adds `gfortran` to `HOSTTOOLS`. Fortran is built by
the configured cross-compiler and no host `gfortran` is ever invoked, so
the only effect of that line is to reject build hosts that do not happen
to have one installed. Because the include is pulled in from
`meta-ros-common`'s `layer.conf`, the rejection happens before any recipe
is parsed:

```
ERROR: The following required tools (as specified by HOSTTOOLS) appear
to be unavailable in PATH, please install them in order to proceed:
  gfortran
```

Dropping the line leaves Fortran enabled exactly as before, through the 
cross-toolchain.

### 2. `{lyrical} osrf-pycommon: populate the Python split package`

The bbappend declares a `python3-osrf-pycommon` split package but appends
it to `PACKAGES` after `${PN}`, so package splitting assigns the 
site-packages files to the main package first and the split package is
emitted empty. `launch-ros` runtime-depends on the rosdep name
`python3-osrf-pycommon`, so image construction fails with `nothing
provides python3-osrf-pycommon needed by launch-ros`.

Prepending it with `=+` lets it claim the modules without adding an
`RPROVIDES` alias.

**Credit, and a request to reconsider #1780.** This is not a new 
discovery. @maxweberhohengrund reported and fixed it in #1780, using
`RPROVIDES` on the base package, and explicitly offered this ordering
change as the alternative:

> An alternative would be to make the subpackage real by reordering the 
> package assignment (PACKAGES =+ instead of +=) so the python package
> claims the site-packages files first. RPROVIDES was chosen as the 
> minimal change that is verified; happy to rework if you prefer the 
> subpackage approach.

So the approach here is his, and the commit carries a `Suggested-by`
trailer for it. 

#1780 was closed on 2026-07-20 as already resolved by 0d99c1ce98e4 and
bd4d11d7e714. Those two extend the recipe for native builds and do not 
change the `PACKAGES` ordering, so the defect survived the closure: the 
`PACKAGES +=` line is still there at the tip of this branch, which is
why the patch here applies cleanly.

I have no attachment to which of the two fixes lands. If you prefer the 
`RPROVIDES` form, the right outcome is to reopen #1780 rather than take
this, and I am happy to drop this patch from the series.

### 3. `{ros2} python3-pyqt6: Enable QtSvg module for ROS rqt`

`meta-ros2/dynamic-layers/meta-qt6` builds pyqt6 with `QtWidgets` only,
while `meta-ros2/dynamic-layers/meta-qt5` enables `QtSvg` for rqt's SVG 
icons. An rqt running against Qt6 therefore comes up with its icons
missing. This brings the Qt6 dynamic layer level with the Qt5 one.

**Credit.** This is the Qt6 counterpart of @chkohn's ffa66d97c4e4,
"{ros2} python3-pyqt5: Enable QtSvg module for ROS rqt", and the in-file
comment is taken from that patch unchanged. He has not reviewed this Qt6 
version, so it carries a `Suggested-by` rather than his sign-off. If he
would prefer to own it, I will happily drop it here and let him send it. 

### 4. `{rolling} osrf-pycommon: populate the Python split package`

`meta-ros2-rolling`'s `osrf-pycommon_2.1.7-1.bbappend` has the identical
`PACKAGES +=` ordering and therefore the identical defect. The two 
bbappends are in fact byte-identical, to the point that git stores them
as the same blob, `f20bdba66eca`.

@maxweberhohengrund flagged Rolling in #1780 and @vermaete asked for it
there ("same for rolling, please"); neither happened when that PR was 
closed, so it is included here.

**This one is not build-tested.** Lyrical was built; Rolling was not. It
is offered on the strength of the construct being identical. If you would
rather see it verified first, drop this patch and take the other three.

### Testing

Built an AArch64 Cortex-A53 image carrying the ROS 2 Lyrical base and 
demo package set. Without the first two changes the build fails twice: at
parse time on the missing host Fortran compiler, and at image
construction on the unsatisfiable `python3-osrf-pycommon` dependency.
With both applied the image completes.

In the interest of being precise about what was and was not run: that
image was built with these changes on `be3e675d84ce`, and they are 
rebased here onto `2ebdb0b8691a`. None of the 21 commits in between touch
any of the four files, and all four patches apply without fuzz, but the 
image has not been rebuilt on the newer tip.

The Rolling patch was not built at all, as noted in its section above.

The QtSvg change has been in use in a Qt6 layer set since it migrated off
Qt5, which is where the missing icons were observed and where enabling
QtSvg was confirmed to restore them.