### PR TITLE
[master]{common}{ros2} ptest: adding file to run ptest

### DIFF
--- a/meta-ros-common/conf/include/ptest-packagelists-meta-ros.inc
+++ b/meta-ros-common/conf/include/ptest-packagelists-meta-ros.inc
@@ -1,0 +1,18 @@
+#
+# Lists of the ptest in meta-ros, sorted into two sets by the time they take
+# Please keep these sorted in alphabetical order
+#
+# ptests which take less than ~30s each
+PTESTS_FAST_META_ROS = "\
+    python3-junitparser \
+    python3-rosdep \
+    python3-rosdistro \
+    python3-rosdoc2 \
+    python3-rospkg \
+"
+
+PTESTS_SLOW_META_ROS = "\
+"
+
+PTESTS_PROBLEMS_META_ROS = "\
+"

--- a/meta-ros-common/recipes-core/images/meta-ros-image-ptest-all.bb
+++ b/meta-ros-common/recipes-core/images/meta-ros-image-ptest-all.bb
@@ -1,0 +1,25 @@
+DESCRIPTION = "Recipe to trigger execution of all meta-ros ptest images."
+HOMEPAGE = "https://www.ros.org/"
+
+LICENSE = "MIT"
+
+inherit features_check nopackages
+REQUIRED_DISTRO_FEATURES = "ptest"
+
+require conf/include/ptest-packagelists-meta-ros.inc
+
+# Include the full set of ptests
+PTESTS_META_ROS = "${PTESTS_FAST_META_ROS} ${PTESTS_SLOW_META_ROS}"
+
+do_testimage[noexec] = "1"
+do_testimage[depends] = "${@' '.join(['meta-ros-image-ptest-'+x+':do_testimage' for x in d.getVar('PTESTS_META_ROS').split()])}"
+
+do_build[depends] = "${@' '.join(['meta-ros-image-ptest-'+x+':do_build' for x in d.getVar('PTESTS_META_ROS').split()])}"
+
+# normally image.bbclass would do this
+EXCLUDE_FROM_WORLD = "1"
+
+python () {
+    if bb.utils.contains('IMAGE_CLASSES', 'testimage', True, False, d):
+        bb.build.addtask("do_testimage", "", "", d)
+}

--- a/meta-ros-common/recipes-core/images/meta-ros-image-ptest-fast.bb
+++ b/meta-ros-common/recipes-core/images/meta-ros-image-ptest-fast.bb
@@ -1,0 +1,5 @@
+require meta-ros-image-ptest-all.bb
+
+DESCRIPTION = "Recipe to trigger execution of all fast meta-ros ptest images."
+
+PTESTS_META_ROS = "${PTESTS_FAST_META_ROS}"

--- a/meta-ros-common/recipes-core/images/meta-ros-image-ptest.bb
+++ b/meta-ros-common/recipes-core/images/meta-ros-image-ptest.bb
@@ -1,0 +1,39 @@
+inherit features_check
+REQUIRED_DISTRO_FEATURES = "ptest"
+
+require recipes-core/images/ros-image-core.bb
+require conf/include/ptest-packagelists-meta-ros.inc
+
+SUMMARY = "meta-ros ptest test image"
+
+DESCRIPTION += "Also including the ${MCNAME} ptest package."
+HOMEPAGE = "https://www.ros.org/"
+
+PTESTS_META_ROS = "${PTESTS_SLOW_META_ROS} ${PTESTS_FAST_META_ROS} ${PTESTS_PROBLEMS_META_ROS}"
+
+IMAGE_INSTALL:append = " ${MCNAME}-ptest openssh"
+
+BBCLASSEXTEND = "${@' '.join(['mcextend:'+x for x in d.getVar('PTESTS_META_ROS').split()])}"
+
+# The image can be sufficiently large (~1.8GB) that we need to be careful that it fits in a live
+# image (which has a 4GB limit), so nullify the overhead factor (1.3x out of the
+# box) and explicitly add up to 1500MB.
+IMAGE_OVERHEAD_FACTOR = "1.0"
+IMAGE_ROOTFS_EXTRA_SPACE = "324288"
+# If a particular ptest needs more space, it can be customized:
+#IMAGE_ROOTFS_EXTRA_SPACE:virtclass-mcextend-<pn> = "1024288"
+
+# ptests need more memory than standard to avoid the OOM killer
+QB_MEM = "-m 1024"
+# If a particular ptest needs more memory, it can be customized:
+#QB_MEM:virtclass-mcextend-<pn> = "-m 4096"
+
+TEST_SUITES = "ping ssh parselogs ptest"
+
+# Sadly at the moment the full set of ptests is not robust enough and sporadically fails in random places
+PTEST_EXPECT_FAILURE = "1"
+
+python () {
+    if not d.getVar("MCNAME"):
+        raise bb.parse.SkipRecipe("No class extension set")
+}


### PR DESCRIPTION
@robwoolley Here the files to get the ptests for ROS running

This is what I'm using now to run them:

setup.sh:

```
#! /bin/bash

# clone meta-oeros
git clone https://github.com/robwoolley/meta-oeros

# patch meta-oeros
cd meta-oeros
git fetch origin pull/1/head && git merge --no-edit FETCH_HEAD
git fetch origin pull/3/head && git merge --no-edit FETCH_HEAD
cd ..

# clone bitbake for bitbake-setup
git clone https://github.com/openembedded/bitbake

#MACHINE=qemux86-64
#MACHINE=raspberrypi5
./bitbake/bin/bitbake-setup init \
                            --non-interactive \
                            meta-oeros/conf/registry/configurations/oeros-master-rolling.conf.json \
                            oeros-master-rolling machine/${MACHINE:-qemux86-64}

# to do
cat <<EOF > bitbake-builds/site.conf
# Limit the resources Yocto will take
BB_NUMBER_THREADS = "4"
PARALLEL_MAKE = "-j4"

DL_DIR = "/var/lib/yocto/downloads/"
SSTATE_DIR = "/var/lib/yocto/sstate-cache"
BB_HASHSERVE_DB_DIR = "\${SSTATE_DIR}"

INHERIT += "report-error"

INHERIT += "rm_work"

BBMASK += "meta-python-ai/recipes-python-updates/twine"
BBMASK += "meta-python-ai/recipes-python/tblib"
BBMASK += "meta-python-ai/recipes-python/tenacity"

IMAGE_CLASSES += "testimage"

ERROR_QA:remove = "license-format"
EOF

pushd .
. ./bitbake-builds/oeros-master-rolling/build/init-build-env
popd

# add the meta-oeros layer itself
bitbake-layers add-layer meta-oeros

bitbake-config-build enable-fragment core/yocto/root-login-with-empty-password
bitbake-config-build enable-fragment core/yocto-autobuilder/autobuilder
bitbake-config-build enable-fragment oeros/allow-commercial-licenses
```

run.sh:

```
#! /bin/sh

. bitbake-builds/oeros-master-rolling/build/init-build-env

bitbake --continue meta-ros-image-ptest-all

bitbake meta-ros-image-ptest-all:do_testimage -k
```

And I had to tweak some stuff on my Debian 13 machine:

```
jan@jan:~/projects/ros$ cat /etc/sudoers.d/ptest 
jan ALL=(ALL:ALL) NOPASSWD: ALL
```
```
# allow network access in qemu
sudo /home/jan/projects/ros/bitbake-builds/oeros-master-rolling/layers/openembedded-core/scripts/runqemu-gen-tapdevs 1000 1
```

```
jan@jan:~/projects/ros$ cat /etc/NetworkManager/NetworkManager.conf
[main]
plugins=ifupdown,keyfile

[ifupdown]
managed=false

[keyfile]
unmanaged-devices=interface-name:tap*
```

~/.ssh/config
```
Host 192.168.7.*
    StrictHostKeyChecking no
    UserKnownHostsFile=/dev/null
```

```
sudo apt install sysstat
sudo apt install iproute2
```
